### PR TITLE
Bugfix/vocab sheet not displaying correctly

### DIFF
--- a/app/assets/stylesheets/_vocab_sheet.scss
+++ b/app/assets/stylesheets/_vocab_sheet.scss
@@ -6,6 +6,14 @@
 .vocab_sheet {
   position: relative;
   text-align: center;
+  ul {
+    padding: 0;
+    margin-left: auto;
+    list-style-type: none;
+    display: flex;
+    flex-wrap: wrap;
+    align-content: flex-start;
+  }
 }
 
 /* bar specific */


### PR DESCRIPTION
UL styling for the vocab sheet was mistakenly removed during a refactor.
This adds it back in to get styles displaying properly again.