### PR TITLE
Auto corrected by following Ruby EmptyLine

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,7 +35,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.


### PR DESCRIPTION
Auto corrected by following Ruby EmptyLine

Click [here](https://awesomecode.io/projects/58/ruby_config_groups/541) to configure it on awesomecode.io