### PR TITLE
configure puppeteer to launch in no sandbox mode for running on heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 cache: bundler
 env:
   global:
-  - CI=true  
   - S3_BUCKET_URL=http://s3-ap-southeast-2.amazonaws.com/test-asset-bucket/
   - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct;
     else git log -1 --skip 1 --pretty=format:%ct; fi)

--- a/bin/render-pdf.js
+++ b/bin/render-pdf.js
@@ -13,15 +13,14 @@ const puppeteer = require("puppeteer");
 const inputPath = `file://${process.argv[2]}`;
 const outputPath = process.argv[3];
 
-/* Travis needs an argument that is generally not prefered
-for live environments so we se it set it optionally here */
-const puppeteerArgs = process.env["CI"] ? ["--no-sandbox"] : [];
-
 console.log("Input path:", inputPath);
 console.log("Output path:", outputPath);
 
+/* Usually we'd prefer not to launch puppeteer with the no-sandbox argument,
+but due to issues getting it running on Heroku this option is required. */
+
 (async () => {
-  const browser = await puppeteer.launch({args: puppeteerArgs});
+  const browser = await puppeteer.launch({args: ["--no-sandbox"]});
   const page = await browser.newPage();
 
   console.log("Starting PDF conversion");


### PR DESCRIPTION
Puppeteer has issues launching chrome on heroku (see here: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-on-heroku )

To work around this we need to install an extra build pack to get things running which can be viewed here https://github.com/jontewks/puppeteer-heroku-buildpack.

Part of the requirement for that buildpack is to set the no-sandbox argument when launching puppeteer so I've made that change here and left a comment in the file indicating why its needed.