### PR TITLE
Stop no index meta tag from rendering except for on staging environment

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,7 +4,8 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %meta{:charset => "utf-8"}/
     %meta{content: "width=device-width, initial-scale=1.0", name: "viewport"}/
-    %meta{content: "noindex", :name => "robots"}/
+    - if staging_env?
+      %meta{content: "noindex", :name => "robots"}/
     %meta{content: "#{t("layout.meta_description")}", name: "description"}/
     %meta{content: "IE-edge,chrome=1", "http-equiv" => "X-UA-Compatible"}/
     - if protect_against_forgery?


### PR DESCRIPTION
During the course of our current block of SEO improvement work I've found that the robots noindex tag is being rendered for all environments. 
This is definitely something that we don't want to do and is counter to our current work so here i'm re-implementing an old helper method so that we only render that tag on staging.