### PR TITLE
remove download buttons from signs show and vocab sheet pages

### DIFF
--- a/app/views/signs/show.html.haml
+++ b/app/views/signs/show.html.haml
@@ -17,10 +17,6 @@
         %h2.main_gloss= @sign.gloss_main
         %h2.main_gloss.maori-gloss= @sign.gloss_maori
       .buttons-container
-        = link_to "/images/signs/400-400/#{@sign.drawing}", { class: "download-link", "data-sign-id": @sign.id } do
-          %span
-            = image_tag "/assets/ui/download-button.svg", class: "card__button download-button"
-          %span.buttons-action  Download Drawing
         = link_to "#", { class: "card__button add-to-vocab-btn sign__button--peach", "data-sign-id": @sign.id } do
           %span.icon-container.add-button-icon
             %i.fi-plus

--- a/app/views/vocab_sheets/_vocab_sheet_item.html.haml
+++ b/app/views/vocab_sheets/_vocab_sheet_item.html.haml
@@ -4,10 +4,6 @@
       = hidden_field_tag "item[#{vocab_sheet_item.id}][id]", vocab_sheet_item.id, class: 'item_id'
       = link_to sign_url(vocab_sheet_item.sign_id), { class: "drawing vocab_sheet_drawing drawing vocab_sheet_drawing__size--#{size}" } do
         = image_tag "/images/signs/400-400/#{vocab_sheet_item.drawing}"
-        = link_to "/images/signs/400-400/#{vocab_sheet_item.drawing}" do
-          %span.icon-container
-            = image_tag "/assets/ui/download-button.svg", class: "vocab-download-button"
-          %span.text-container
       = form_tag vocab_sheet_item_path(vocab_sheet_item), method: :put do
         = text_area_tag "item[name]", vocab_sheet_item.name, class: 'item-name vocab-sheet__text-input h3', id: "item_#{vocab_sheet_item.id}_name", maxlength:vocab_sheet_max_field_length
         = hidden_field_tag "item[#{vocab_sheet_item.id}][old_name]", vocab_sheet_item.name, class: 'old_name'


### PR DESCRIPTION
The high resolution image downloading story wont be ready to go for another wee while yet because new images need to be uploaded. So as not to undo too much of the work thats been put into this functionality so far, this PR removes just the buttons from the views so that we can merge staging into prod for a final deploy.

The next feature branch for this functionality can revert this commit and continue with the new addtions