### PR TITLE
Change test command for README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ git clone <your fork>
 cp env-example .env
 bundle
 yarn
+rails s
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ git clone <your fork>
 cp env-example .env
 bundle
 yarn
-bundle exec rspec spec
+bundle exec rspec 
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ git clone <your fork>
 cp env-example .env
 bundle
 yarn
-bundle exec rails s
+bundle exec rspec spec
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ git clone <your fork>
 cp env-example .env
 bundle
 yarn
-bundle exec rspec 
 
 ```
 
@@ -57,7 +56,7 @@ A suggestion is to create a local staging branch that acts as your local master.
 
 ## Running the tests
 
-`bundle exec rails test`
+`bundle exec rspec`
 
 ## Design and brand guidelines  
 


### PR DESCRIPTION
This PR changes the test command to use the correct rspec command in the README for open source contributors