### PR TITLE
Fix ActionView::MissingTemplate errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,7 +64,7 @@ class ApplicationController < ActionController::Base
   def render_404
     @page = Page.find(Setting.get(:'404'))
     if @page
-      render template: "pages/#{@page.template}", status: 404
+      render template: "pages/#{@page.template}", status: 404, formats: :html
     else
       render text: '404 - page not found', status: 404
     end


### PR DESCRIPTION
Rails was raising `ActionView::MissingTemplate` whenever a client
requested a URL which did not exist e.g. `https://www.nzsl.nz/blah.txt`

This change fixes that and allows Rails to render the expected template
in response to requests for pages which don't exist.

Before this change:

![screenshot 2018-12-21 12 39 54](https://user-images.githubusercontent.com/599867/50316894-8da37100-051d-11e9-9f9c-aa26de9a3d46.png)

An exception would also be logged to Raygun

After the change:

![screenshot 2018-12-21 12 38 12](https://user-images.githubusercontent.com/599867/50316857-5e8cff80-051d-11e9-8946-47d001b6a69f.png)

This change should reduce the noise in Raygun significantly.

