### PR TITLE
Stop using 'nothing' option in `render` as Rails 5 removed it.

### DIFF
--- a/app/controllers/admin/page_parts_controller.rb
+++ b/app/controllers/admin/page_parts_controller.rb
@@ -44,7 +44,7 @@ module Admin
       params[:items].each_with_index do |id, index|
         PagePart.find(id.to_i).update(order: index + 1)
       end
-      render nothing: true
+      head :ok
     end
 
     private

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -43,7 +43,7 @@ module Admin
       params[:items].each_with_index do |id, index|
         Page.find(id.to_i).update(order: index + 1)
       end
-      render nothing: true
+      head :ok
     end
 
     private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -68,7 +68,7 @@ class ItemsController < ApplicationController
         updated_at: Time.current
       )
     end
-    render nothing: true
+    head :ok
   end
 
   private

--- a/app/controllers/signs_controller.rb
+++ b/app/controllers/signs_controller.rb
@@ -22,7 +22,7 @@ class SignsController < ApplicationController
     if permitted_params[:term].present?
       render json: open("#{AUTOCOMPLETE_URL}?q=#{CGI.escape(permitted_params[:term])}&limit=10", &:read).split("\n")
     else
-      render :nothing
+      head :ok
     end
   end
 


### PR DESCRIPTION
Rails 5 deprecated `render nothing: true` and encourages you to use `head :ok` instead - see
https://edgeguides.rubyonrails.org/5_0_release_notes.html#action-pack-deprecations

This was not causing any failing functionality for users but it was causing exceptions to be sent to Raygun.

This change updates the code to use `head :ok`.