### PR TITLE
Fix bug where invalid feedback was causing an exception to be raised.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 before_script:
 - gem install  --no-rdoc --no-ri 'brakeman' 'bundler-audit' 'pandoc-ruby'
 - nvm install node 9.10.0
-- npm install -g yarn@1.5.1
+- npm install -g yarn
 - yarn install
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
 - chmod +x ./cc-test-reporter
@@ -21,6 +21,7 @@ before_script:
 addons:
   apt_packages:
     - pandoc
+    - google-chrome-stable
   code_climate:
     repo_token: CC_TEST_REPORTER_ID
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,8 @@ end
 group :test do
   gem 'capybara'
   gem 'capybara-screenshot'
+  gem 'capybara-selenium'
+  gem 'chromedriver-helper'
   gem 'codeclimate-test-reporter', '~> 1.0.9'
   gem 'database_cleaner'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.4.3)
@@ -70,6 +72,14 @@ GEM
     capybara-screenshot (1.0.22)
       capybara (>= 1.0, < 4)
       launchy
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (2.1.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     chronic (0.10.2)
     ckeditor_rails (4.10.0)
       railties (>= 3.0)
@@ -99,7 +109,7 @@ GEM
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
-    erubi (1.7.1)
+    erubi (1.8.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -127,6 +137,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.3.0)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jaro_winkler (1.5.1)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
@@ -274,6 +285,7 @@ GEM
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
+    rubyzip (1.2.2)
     sass (3.4.25)
     sass-rails (5.0.7)
       railties (>= 4.0.0, < 6)
@@ -281,6 +293,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.141.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2, >= 1.2.2)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -333,6 +348,8 @@ DEPENDENCIES
   browser
   capybara
   capybara-screenshot
+  capybara-selenium
+  chromedriver-helper
   ckeditor_rails
   codeclimate-test-reporter (~> 1.0.9)
   coffee-rails

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -7,25 +7,30 @@ class FeedbackController < ApplicationController
     @feedback = Feedback.new
   end
 
-  def create # rubocop:disable Metrics/AbcSize
-    begin
-      @feedback = Feedback.create(feedback_params)
-      if @feedback.valid?
-        @feedback.send_email
-        @feedback = Feedback.new
-        flash.now[:feedback_notice] = t('feedback.success')
-      else
-        flash.now[:feedback_error] = t('feedback.failure')
-      end
-    rescue StandardError
-      flash.now[:feedback_error] = t('feedback.failure')
-    end
+  def create
+    process_feedback
+
+    @feedback = Feedback.new
     @page = Page.find(params[:page_id].to_i)
     @title = @page.title
+
     render template: "pages/#{@page.template}"
   end
 
   private
+
+  def process_feedback
+    feedback = Feedback.create(feedback_params)
+
+    if feedback.valid?
+      feedback.send_email
+      flash.now[:feedback_notice] = t('feedback.success')
+    else
+      flash.now[:feedback_error] = t('feedback.failure')
+    end
+  rescue StandardError
+    flash.now[:feedback_error] = t('feedback.failure')
+  end
 
   def feedback_params
     params.require(:feedback).permit(:name, :message, :video, :email)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@
 
 require 'csv'
 
-def load(data_type)
+def load_data(data_type)
   data_klass = data_type.to_s.singularize.camelize.constantize
   data_klass.transaction do
     CSV.foreach(csv_filename(data_type)) do |row|
@@ -20,6 +20,6 @@ def csv_filename(data_type)
   filename
 end
 
-load(:settings)
-load(:pages)
-load(:page_parts)
+load_data(:settings)
+load_data(:pages)
+load_data(:page_parts)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/ODNZSL/nzsl-online#readme",
   "engines": {
     "node": ">=9.10.0",
-    "yarn": "1.5.1"
+    "yarn": ">=1.5.1"
   },
   "dependencies": {
     "eslint": "^5.0.0",

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,14 +54,27 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with :truncation
+  # Stop puma from printing its normal startup output in
+  # the middle of your test output
+  config.before(:all, type: :system) do
+    Capybara.server = :puma, { Silent: true }
   end
 
-  config.around do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :selenium_chrome_headless
+
+    # Use :selenium_chrome in development if you want Chrome browser windows to
+    # appear - this is convenient for debugging issues because `binding.pry` in
+    # your test will keep the Chrome window open and let you inspect what is
+    # really going on.
+    #
+    # This driver should only be enabled for local developer testing and the
+    # change should not be checked into git.
+    #
+    # driven_by :selenium_chrome
   end
 end

--- a/spec/system/feedback_spec.rb
+++ b/spec/system/feedback_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe 'User Feedback', type: :system do
 
   it 'submits the feedback form if all required fields are present', js: true do
     visit page_path(slug: 'contact-us')
-    expect(page).to have_text('Deaf Studies Research Unit')
 
     fill_in 'Name', with: "Miles Edward O'Brien"
     fill_in 'Email', with: 'milesobrien@transporter-rm3.enterprise'
@@ -26,7 +25,6 @@ RSpec.describe 'User Feedback', type: :system do
 
   it 'Shows an error if required fields are missing', js: true do
     visit page_path(slug: 'contact-us')
-    expect(page).to have_text('Deaf Studies Research Unit')
 
     fill_in 'Name', with: "Miles Edward O'Brien"
     fill_in 'Email', with: 'milesobrien@transporter-rm3.enterprise'
@@ -43,7 +41,6 @@ RSpec.describe 'User Feedback', type: :system do
     allow(Feedback).to receive(:create).and_raise(RuntimeError)
 
     visit page_path(slug: 'contact-us')
-    expect(page).to have_text('Deaf Studies Research Unit')
 
     fill_in 'Name', with: "Miles Edward O'Brien"
     fill_in 'Email', with: 'milesobrien@transporter-rm3.enterprise'

--- a/spec/system/feedback_spec.rb
+++ b/spec/system/feedback_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'User Feedback', type: :system do
+  before(:all) do
+    # These tests require the seed data to be present
+    Rails.application.load_seed
+  end
+
+  after(:all) do
+    # Truncate the DB to remove any seed data we added in the before(:all) hook
+    DatabaseCleaner.clean_with :truncation
+  end
+
+  it 'submits the feedback form if all required fields are present', js: true do
+    visit page_path(slug: 'contact-us')
+    expect(page).to have_text('Deaf Studies Research Unit')
+
+    fill_in 'Name', with: "Miles Edward O'Brien"
+    fill_in 'Email', with: 'milesobrien@transporter-rm3.enterprise'
+    fill_in 'Message', with: 'Anybody there?'
+
+    click_on "Send Feedback"
+
+    expect(page).to have_text('Your feedback has been sent')
+  end
+
+  it 'Shows an error if required fields are missing', js: true do
+    visit page_path(slug: 'contact-us')
+    expect(page).to have_text('Deaf Studies Research Unit')
+
+    fill_in 'Name', with: "Miles Edward O'Brien"
+    fill_in 'Email', with: 'milesobrien@transporter-rm3.enterprise'
+    # we deliberately forget to fill in the "Message" field
+
+    click_on "Send Feedback"
+
+    expect(page).to have_text("Your feedback didn't send")
+  end
+
+  it 'Shows an error if an exception was raised while processing feedback', js: true do
+    # Deliberately break the Feedback model (for the duration of this test) so
+    # it will raise an error during creation of an instance
+    allow(Feedback).to receive(:create).and_raise(RuntimeError)
+
+    visit page_path(slug: 'contact-us')
+    expect(page).to have_text('Deaf Studies Research Unit')
+
+    fill_in 'Name', with: "Miles Edward O'Brien"
+    fill_in 'Email', with: 'milesobrien@transporter-rm3.enterprise'
+    fill_in 'Message', with: 'Anybody there?'
+
+    click_on "Send Feedback"
+
+    expect(page).to have_text("Your feedback didn't send")
+  end
+end


### PR DESCRIPTION
An exception was being raised whenever a user submitted an invalid feedback form because the `@feedback` ivar was not being set properly in this case.

This change

* fixes that bug
* sets up system tests in the app (Rails recommends system tests since 5.1. They can happily live beside existing feature tests but most (future) Rails devs will be more familiar with them so I thought it was better to bite the bullet)
* add some system tests for the feedback form
