### PR TITLE
Fix bug triggered by WEB_CONCURRENCY env var being a string not a number

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,7 @@ default: &default
   # available to be able to run things like `rails console` without impacting
   # the worker processes.
   #
-  pool: <%= ENV["DB_POOL"] || (ENV.fetch('WEB_CONCURRENCY', 3) + 2) || 5 %>
+  pool: <%= ENV["DB_POOL"] || (Integer(ENV.fetch("WEB_CONCURRENCY", "3")) + 2) %>
 
 development:
   <<: *default


### PR DESCRIPTION
When Heroku sets WEB_CONCURRENCY to a string representation of a number,
not an actual number e.g. "3" not 3. This change accounts for that properly
when configuring the DB pool size at application startup

This change also removes the `|| 5` fallback which will never be used because
the fetch of WEB_CONCURRENCY from the env has a default value fallback.