### PR TITLE
Improve error reporting of freelex comms issues

### DIFF
--- a/app/models/sign.rb
+++ b/app/models/sign.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
+
 require 'nokogiri'
 
 ## a sign in New Zealand Sign Language
 class Sign
+  # Create a custom error class.
+  #
+  # * Callers of this class can `rescue` one exception class if they want to
+  #   catch **all** possible exceptions from this class.
+  # * All uncaught exceptions related to this class are grouped together in
+  #   exception monitoring tools.
+  #
+  class FreelexCommunicationError < StandardError; end
 
   ELEMENT_NAME = 'entry'
 
@@ -69,7 +78,7 @@ class Sign
 
   def self.search(params)
     xml_request(params)
-  rescue OpenURI::HTTPError => e
+  rescue FreelexCommunicationError => e
     Raygun.track_exception(e)
     [0, []]
   end
@@ -79,6 +88,14 @@ class Sign
     entries = xml_document.css(ELEMENT_NAME)
     count = xml_document.css('totalhits').inner_text.to_i
     [count, entries]
+  rescue Faraday::ConnectionFailed
+    raise(FreelexCommunicationError, 'Failed to connect')
+  rescue Faraday::TimeoutError
+    raise(FreelexCommunicationError, 'Connection timeout')
+  rescue Faraday::Error
+    raise(FreelexCommunicationError, 'Generic communication error')
+  rescue Nokogiri::SyntaxError
+    raise(FreelexCommunicationError, 'Failed to parse response')
   end
 
   def self.uri_for_search(query)

--- a/app/models/sign.rb
+++ b/app/models/sign.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
+require 'nokogiri'
 
 ## a sign in New Zealand Sign Language
 class Sign
-  require 'nokogiri'
 
   ELEMENT_NAME = 'entry'
 

--- a/app/models/sign.rb
+++ b/app/models/sign.rb
@@ -120,15 +120,7 @@ class Sign
   def self.http_conn
     Faraday.new(url: SIGN_URL) do |faraday|
       faraday.use FaradayMiddleware::FollowRedirects
-
-      # Heroku enforces a 30 second timeout on our generating a response. We
-      # set a timeout for Freelex that allows us time to process the response
-      # and return it to our client within that constraint.
-      #
-      # Faraday timeout option specifies when how long we should wait (in
-      # seconds) for data to be available to be read from the socket
-      faraday.options[:timeout] = 20
-
+      faraday.options.timeout = FREELEX_TIMEOUT
       faraday.adapter Faraday.default_adapter
     end
   end

--- a/app/models/sign.rb
+++ b/app/models/sign.rb
@@ -103,7 +103,15 @@ class Sign
   def self.http_conn
     Faraday.new(url: SIGN_URL) do |faraday|
       faraday.use FaradayMiddleware::FollowRedirects
-      faraday.options[:timeout] = 60
+
+      # Heroku enforces a 30 second timeout on our generating a response. We
+      # set a timeout for Freelex that allows us time to process the response
+      # and return it to our client within that constraint.
+      #
+      # Faraday timeout option specifies when how long we should wait (in
+      # seconds) for data to be available to be read from the socket
+      faraday.options[:timeout] = 20
+
       faraday.adapter Faraday.default_adapter
     end
   end

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -4,3 +4,13 @@ SIGN_URL         = 'http://nzsl-assets.vuw.ac.nz/dnzsl/freelex/publicsearch'
 ASSET_URL        = 'http://nzsl-assets.vuw.ac.nz/dnzsl/freelex/assets/'
 AUTOCOMPLETE_URL = 'http://nzsl-assets.vuw.ac.nz/dnzsl/ncbin/public_search_lookup'
 ADMIN_EMAIL      = 'micky.vale@vuw.ac.nz'
+
+##
+# Heroku enforces a 30 second timeout on our generating a response. We set a
+# timeout for Freelex that allows us time to process the response and return it
+# to our client within that constraint.
+#
+# This timeout option specifies when how long we should wait (in seconds) for
+# data to be available to be read from the socket.
+#
+FREELEX_TIMEOUT = 20 # seconds


### PR DESCRIPTION
This PR makes the following changes:

### Create Sign::FreelexCommunicationError exception class

A custom exception class will allow us to see all the exceptions related to this class in a single group in our exception reporting - currently those errors are spread across many exception classes making it it difficult to troubleshoot.

### Change Freelex timeout from 60 sec to 20 sec.

Heroku enforces a 30 second timeout (details: https://devcenter.heroku.com/articles/request-timeout) on our generating a complete response. We set a timeout for Freelex that allows us time to process the response and return it to our client within that constraint.

Before this change, timeout and connection delays were sometimes being reported as different exceptions e.g. `ActionView::Template::Error because the Heroku timeout would cause Rails to fail elsewhere in its processing.


closes #383