### PR TITLE
Refactor autocomplete search and improve error handling & logging

### DIFF
--- a/app/controllers/signs_controller.rb
+++ b/app/controllers/signs_controller.rb
@@ -24,11 +24,14 @@ class SignsController < ApplicationController
   end
 
   def autocomplete
-    if permitted_params[:term].present?
-      render json: open("#{AUTOCOMPLETE_URL}?q=#{CGI.escape(permitted_params[:term])}&limit=10", &:read).split("\n")
-    else
-      head :ok
+    search_term_param = permitted_params[:term]
+
+    if search_term_param.blank?
+      head(:ok)
+      return
     end
+
+    render json: AutocompleteSearchService.new(search_term: search_term_param).find_suggestions
   end
 
   private

--- a/app/services/autocomplete_search_service.rb
+++ b/app/services/autocomplete_search_service.rb
@@ -2,6 +2,8 @@ class AutocompleteSearchService
   MAX_NUM_SUGGESTIONS = 10
   AUTOCOMPLETE_SEARCH_TIMEOUT = 10 # seconds
 
+  class AutocompleteSearchServiceError < StandardError; end
+
   ##
   # @param [String] search_term
   # @param [Faraday::Connection] faraday_connection - has a sensible default value which can be overridden by test code
@@ -43,6 +45,7 @@ class AutocompleteSearchService
         * Error details:
           #{e}
     EO_MSG
+    Raygun.track_exception(AutocompleteSearchServiceError.new(msg))
     @logger.warn(msg)
 
     []

--- a/app/services/autocomplete_search_service.rb
+++ b/app/services/autocomplete_search_service.rb
@@ -1,0 +1,63 @@
+class AutocompleteSearchService
+  MAX_NUM_SUGGESTIONS = 10
+  AUTOCOMPLETE_SEARCH_TIMEOUT = 10 # seconds
+
+  ##
+  # @param [String] search_term
+  # @param [Faraday::Connection] faraday_connection - has a sensible default value which can be overridden by test code
+  # @param [Logger] logger - has a sensible default value which can be overridden by test code
+  #
+  def initialize(search_term:, faraday_connection: build_faraday_connection, logger: Rails.logger)
+    @search_term = search_term
+    @faraday_connection = faraday_connection
+    @logger = logger
+  end
+
+  ##
+  # Find MAX_NUM_SUGGESTIONS suggested completions for the given search term.
+  #
+  # @return [Array<String>] array of autocomplete suggestions
+  #
+  def find_suggestions
+    response = @faraday_connection.get do |request|
+      request.params[:limit] = MAX_NUM_SUGGESTIONS
+      request.params[:q] = CGI.escape(@search_term)
+    end
+
+    results = response.body.split("\n")
+
+    if results.length > MAX_NUM_SUGGESTIONS
+      msg = <<~EO_MSG
+        Received #{results.count} autocomplete suggestions (#{results.count - MAX_NUM_SUGGESTIONS} more than expected):
+          #{results}
+      EO_MSG
+
+      @logger.info(msg)
+    end
+
+    results.take(MAX_NUM_SUGGESTIONS)
+  rescue Faraday::Error => e
+    msg = <<~EO_MSG
+      Recovered from failed autocomplete search.
+        * Search term was: #{@search_term}
+        * Error details:
+          #{e}
+    EO_MSG
+    @logger.warn(msg)
+
+    []
+  end
+
+  private
+
+  def build_faraday_connection
+    Faraday.new(url: AUTOCOMPLETE_URL) do |faraday|
+      # log all requests to stdout in development
+      faraday.response :logger if Rails.env.development?
+
+      faraday.use FaradayMiddleware::FollowRedirects
+      faraday.options.timeout = AUTOCOMPLETE_SEARCH_TIMEOUT
+      faraday.adapter Faraday.default_adapter
+    end
+  end
+end

--- a/app/services/autocomplete_search_service.rb
+++ b/app/services/autocomplete_search_service.rb
@@ -18,7 +18,7 @@ class AutocompleteSearchService
   #
   # @return [Array<String>] array of autocomplete suggestions
   #
-  def find_suggestions
+  def find_suggestions # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     response = @faraday_connection.get do |request|
       request.params[:limit] = MAX_NUM_SUGGESTIONS
       request.params[:q] = CGI.escape(@search_term)

--- a/spec/services/autocomplete_search_service_spec.rb
+++ b/spec/services/autocomplete_search_service_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe AutocompleteSearchService do
+  describe "#find_suggestions" do
+    context "When the external services behaves as expected" do
+      let(:search_term) { "Anything" }
+      let(:expected_suggestions) { %w{1 2 3 4 5 6 7 8 9 10} }
+      let(:stubbed_faraday_connection) do
+        Faraday::Connection.new do |faraday|
+          faraday.use Faraday::Adapter::Test do |stub|
+            stub.get '/' do
+              [200, {'Content-Type' => 'text/plain'}, expected_suggestions.join("\n")]
+            end
+          end
+        end
+      end
+
+      subject { AutocompleteSearchService.new(search_term: search_term, faraday_connection: stubbed_faraday_connection) }
+
+      it "Returns the expected suggestions" do
+        results = subject.find_suggestions
+        expect(results).to eq(expected_suggestions)
+      end
+    end
+
+    context "When there is an error communicating with the external search service" do
+      let(:search_term) { "Anything" }
+      let(:expected_suggestions) { %w{1 2 3 4 5 6 7 8 9 10} }
+      let(:stubbed_faraday_connection) do
+        Faraday::Connection.new do |faraday|
+          faraday.use Faraday::Adapter::Test do |stub|
+            stub.get '/' do
+              fail(Faraday::Error, "Simulated autocomplete service failure")
+            end
+          end
+        end
+      end
+      let(:log_accumulator) { "" }
+      let(:logger) do
+        Logger.new(StringIO.new(log_accumulator))
+      end
+
+      subject { AutocompleteSearchService.new(search_term: search_term, faraday_connection: stubbed_faraday_connection, logger: logger) }
+
+      it "Recovers from the error by returning an empty result-set" do
+        results = subject.find_suggestions
+        expect(results).to eq([])
+      end
+
+      it "Logs an explanatory message" do
+        subject.find_suggestions
+        expect(log_accumulator).to include("Recovered from failed autocomplete search")
+      end
+    end
+
+    context "When it receives more than the requested number of results" do
+      let(:search_term) { "Anything" }
+      let(:all_suggestions) { %w{1 2 3 4 5 6 7 8 9 10 11 12} }
+      let(:expected_suggestions) { %w{1 2 3 4 5 6 7 8 9 10} }
+      let(:stubbed_faraday_connection) do
+        Faraday::Connection.new do |faraday|
+          faraday.use Faraday::Adapter::Test do |stub|
+            stub.get '/' do
+              [200, {'Content-Type' => 'text/plain'}, all_suggestions.join("\n")]
+            end
+          end
+        end
+      end
+
+      subject { AutocompleteSearchService.new(search_term: search_term, faraday_connection: stubbed_faraday_connection) }
+
+      it "Discards extra results" do
+        results = subject.find_suggestions
+        expect(results).to eq(expected_suggestions)
+      end
+    end
+  end
+end
+

--- a/spec/services/autocomplete_search_service_spec.rb
+++ b/spec/services/autocomplete_search_service_spec.rb
@@ -47,6 +47,11 @@ RSpec.describe AutocompleteSearchService do
         expect(results).to eq([])
       end
 
+      it "Sends an explanatory error to Raygun" do
+        expect(Raygun).to receive(:track_exception)
+        results = subject.find_suggestions
+      end
+
       it "Logs an explanatory message" do
         subject.find_suggestions
         expect(log_accumulator).to include("Recovered from failed autocomplete search")


### PR DESCRIPTION
* Pull autocomplete searching out into a service object
* Use Faraday instead of built-in `Net::HTTP` because `Faraday` is much more
  disciplined about the exceptions it will raise (they are all under `Faraday::Error`)
* Log a warning and return an empty result-set if anything goes wrong while
  doing the autocomplete search
* Log autocomplete requests in development (handy for debugging)

From my testing it looks like the autocomplete search at `http://nzsl-assets.vuw.ac.nz/dnzsl/ncbin/public_search_lookup` ignores the `limit=10` param we send e.g. this is what I get when the search term is `hea`

```
Received 36 autocomplete suggestions (26 more than expected):
  ["heal", "head", "heat", "hear", "heavy", "heart", "health", "heater", "heaven", "header", "headway", "healthy", "heating", "hearing", "heading", "head for", "headache", "headline", "head lice", "heartburn", "heartbeat", "heartache", "headmaster", "heart rate", "headphones", "hearing aid", "heartbroken", "heart attack", "head teacher", "headquarters", "head spinning", "heavy drinker", "hearing school", "hearing impaired", "hearing aid battery", "hearing aid amplifier"]
```

Are there any docs/code I can look at to see what the deal is there? I've worked around it by trimming the results in the service but it would be better to just ask for the correct number if possible.