### PR TITLE
Generate all URLs to sign images in one place

### DIFF
--- a/app/helpers/signs_helper.rb
+++ b/app/helpers/signs_helper.rb
@@ -20,8 +20,18 @@ module SignsHelper
     end.compact.join(', ').html_safe
   end
 
-  def convert_to_high_resolution(sign_drawing)
-    sign_drawing.gsub(/default.png$/i, 'high_resolution.png')
+  ##
+  # This function should be the one and only place in the app which generates
+  # URLs to sign images.
+  #
+  def sign_image_url(image_name: '', width: 400, height: 400, high_res: false)
+    file_name = if high_res
+                  image_name.gsub(/default.png$/i, 'high_resolution.png')
+                else
+                  image_name
+                end
+
+    "/images/signs/#{width}-#{height}/#{file_name}"
   end
 
   def render_transcription(transcription, id)

--- a/app/views/pages/_grid.html.haml
+++ b/app/views/pages/_grid.html.haml
@@ -13,6 +13,6 @@
                 = ea.first
             - else
               = link_to sign_url(ea.last.id), { class: 'drawing grid_drawing' } do
-                = image_tag "/images/signs/400-400/#{ea.last.drawing}", alt: ea.first
+                = image_tag sign_image_url(image_name: ea.last.drawing), alt: ea.first
               = link_to sign_url(ea.last.id), { class: 'main_gloss' } do
                 = ea.first

--- a/app/views/shared/_vocab_sheet_item.html.haml
+++ b/app/views/shared/_vocab_sheet_item.html.haml
@@ -1,5 +1,5 @@
-%li{ class:"vocab-sheet__item vocab-sidebar__item", "data-sign-id": vocab_sheet_item.id }
-  = image_tag "/images/signs/80-80/#{vocab_sheet_item.drawing}", class: "vocab-sidebar__image"
+%li{ class: "vocab-sheet__item vocab-sidebar__item", "data-sign-id": vocab_sheet_item.id }
+  = image_tag sign_image_url(image_name: vocab_sheet_item.drawing, width: 80, height: 80), class: "vocab-sidebar__image"
   %p.main_gloss.vocab-sidebar__gloss
     = vocab_sheet_item.name
   %p.maori_gloss.vocab-sidebar__gloss

--- a/app/views/signs/_sign_of_the_day.html.haml
+++ b/app/views/signs/_sign_of_the_day.html.haml
@@ -7,7 +7,7 @@
     %div{class: "sign-content-container row", id: "sign-content-container", data: {"equalizer": true }}
       %div{ class: "sign-container small-12 medium-6 float-right", data: {"equalizer-watch": true }}
         = link_to sign_url(sign.id), {class: 'drawing'} do
-          = image_tag "/images/signs/400-400/#{sign.drawing}", class: "sign-image"
+          = image_tag sign_image_url(image_name: sign.drawing), class: "sign-image"
       %div{ class: "video-container small-12 medium-6 float-left", data: {"equalizer-watch": true }}
         %i.fi-play.play-button
         = videojs_rails sources: { mp4: sign.video }, class: "main_video video normal", preload: "auto", controlsList:"nodownload", loop: true, controls: false

--- a/app/views/signs/search.html.haml
+++ b/app/views/signs/search.html.haml
@@ -26,7 +26,7 @@
       .card__bottom-row
         .card__sign-container
           = link_to sign_url(sign.id), { class: 'drawing grid_drawing js-ga-link-submission', onclick: "_gaq.push(['_trackEvent','Search','Click','#{query_text}-#{sign.id}',#{@signs.find_index(sign) + 1}]);" } do
-            = image_tag "/images/signs/400-400/#{sign.drawing}", { class: 'card__drawing-image' }
+            = image_tag sign_image_url(image_name: sign.drawing), { class: 'card__drawing-image' }
         .card__button-container
           = link_to sign_url(sign.id), { class: "card__button" } do
             %span.card__button-symbol.card__button-symbol--blue →

--- a/app/views/signs/show.html.haml
+++ b/app/views/signs/show.html.haml
@@ -12,12 +12,12 @@
       .sign_attributes
         = handshape_image @sign.handshape
         = location_image @sign.location
-      = image_tag "/images/signs/400-400/#{@sign.drawing}", class: "main-image"
+      = image_tag sign_image_url(image_name: @sign.drawing), class: "main-image"
       .glosses-container.glosses
         %h2.main_gloss= @sign.gloss_main
         %h2.main_gloss.maori-gloss= @sign.gloss_maori
       .buttons-container
-        = link_to "/images/signs/400-400/#{convert_to_high_resolution(@sign.drawing)}", { class: "download-link", "data-sign-id": @sign.id } do
+        = link_to sign_image_url(image_name: @sign.drawing, high_res: true), { class: "download-link", "data-sign-id": @sign.id } do
           %span
             = image_tag "ui/download-button.svg", class: "card__button download-button"
           %span.buttons-action  Download Drawing

--- a/app/views/static_pages/_grid.html.haml
+++ b/app/views/static_pages/_grid.html.haml
@@ -13,6 +13,6 @@
                 = ea.first
             - else
               = link_to sign_url(ea.last.id), {class: 'drawing'} do
-                = image_tag "/images/signs/400-400/#{ea.last.drawing}", alt: ea.first, class: "grid-image"
+                = image_tag sign_image_url(image_name: ea.last.drawing), alt: ea.first, class: "grid-image"
               = link_to sign_url(ea.last.id), {class: 'image-caption'} do
                 = ea.first

--- a/app/views/vocab_sheets/_vocab_sheet_item.html.haml
+++ b/app/views/vocab_sheets/_vocab_sheet_item.html.haml
@@ -3,8 +3,8 @@
     .notes-view__gloss
       = hidden_field_tag "item[#{vocab_sheet_item.id}][id]", vocab_sheet_item.id, class: 'item_id'
       = link_to sign_url(vocab_sheet_item.sign_id), { class: "drawing vocab_sheet_drawing drawing vocab_sheet_drawing__size--#{size}" } do
-        = image_tag "/images/signs/400-400/#{vocab_sheet_item.drawing}"
-        = link_to "/images/signs/400-400/#{convert_to_high_resolution(vocab_sheet_item.drawing)}", { class: "download-link"} do
+        = image_tag sign_image_url(image_name: vocab_sheet_item.drawing)
+        = link_to sign_image_url(image_name: vocab_sheet_item.drawing, high_res: true), { class: "download-link"} do
           %span.icon-container
             = image_tag "ui/download-button.svg", class: "vocab-download-button"
           %span.text-container

--- a/spec/helpers/sign_download_helper_spec.rb
+++ b/spec/helpers/sign_download_helper_spec.rb
@@ -12,31 +12,31 @@ RSpec.describe SignsHelper, type: :helper do
   describe '#convert_to_high_resolution' do
     context 'when provided with a "default.png" sign drawing' do
       it 'returns the sign drawing with the text "high_resolution" as part of the file name' do
-        expect(helper.convert_to_high_resolution(drawing_1)).to include('high_resolution.png')
+        expect(helper.sign_image_url(image_name: drawing_1, high_res: true)).to include('high_resolution.png')
       end
     end
 
     context 'when not provided with a "default.png" sign drawing' do
       it 'returns the sign drawing with the text "test02-1234" as part of the file name' do
-        expect(helper.convert_to_high_resolution(drawing_2)).to include('test02-1234.png')
+        expect(helper.sign_image_url(image_name: drawing_2, high_res: true)).to include('test02-1234.png')
       end
     end
 
     context 'when provided with a "default.png" sign drawing and the string "default" as part of the drawing name' do
       it 'returns the sign drawing with the text "default-1234-high_resolution" as part of the file name' do
-        expect(helper.convert_to_high_resolution(drawing_3)).to include('default-1234-high_resolution.png')
+        expect(helper.sign_image_url(image_name: drawing_3, high_res: true)).to include('default-1234-high_resolution.png') # rubocop:disable Metrics/LineLength
       end
     end
 
     context 'when provided with a mixed case "default.png" sign drawing' do
       it 'returns the sign drawing with the text "high_resolution" as part of the file name' do
-        expect(helper.convert_to_high_resolution(drawing_4)).to include('high_resolution.png')
+        expect(helper.sign_image_url(image_name: drawing_4, high_res: true)).to include('high_resolution.png')
       end
     end
 
     context 'when provided with an upper case "default.png" sign drawing' do
       it 'returns the sign drawing with the text "high_resolution" as part of the file name' do
-        expect(helper.convert_to_high_resolution(drawing_5)).to include('high_resolution.png')
+        expect(helper.sign_image_url(image_name: drawing_5, high_res: true)).to include('high_resolution.png')
       end
     end
   end


### PR DESCRIPTION
This refactoring will allow us to make future changes to how we generate URLs to sign images and only have to change `SignsHelper#sign_image_url`. It is a preparatory step for issue #495 

