### PR TITLE
Workaround bug where autocomplete search results have incorrect encoding

### DIFF
--- a/spec/services/autocomplete_search_service_spec.rb
+++ b/spec/services/autocomplete_search_service_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe AutocompleteSearchService do
     context 'When there is an error communicating with the external search service' do
       subject do
         described_class.new(search_term: search_term,
-                                      faraday_connection: stubbed_faraday_connection,
-                                      logger: logger)
+                            faraday_connection: stubbed_faraday_connection,
+                            logger: logger)
       end
 
       let(:search_term) { 'Anything' }


### PR DESCRIPTION
The response from the autocomplete service sets the HTTP header:

    Content-Type: text/html; charset=ISO-8859-1

but in reality the body string is UTF-8. This was causing autocomplete searches which included macrons to fail.

For example, the results for search term "wha" include strings with macrons e.g. "Whangārei". By inspection of the response body in a hex editor the "lowercase a with macron" is 0xC481 which corresponds to the UTF-8 encoding for that grapheme - see https://en.wikipedia.org/wiki/%C4%80

To work around this, we tell ruby to change the encoding tag on the body String (`#force_encoding` only changes the tag, it does not attempt to transcode the data).

### Reproducing the bug

Try doing an autocomplete search for `wha` in production - you will get no results and Raygun will get a 500 from Rails complaining about not being able to change encodings.

 This change fixes that - see this screenshot from my local machine after the fix is applied:

<img width="1091" alt="screenshot 2019-01-16 20 09 43" src="https://user-images.githubusercontent.com/599867/51232157-ccb4cd00-19ca-11e9-9096-7136479416bd.png">
