### PR TITLE
Make production logs more manageable.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'haml'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
+gem 'lograge', '~> 0.10.0'
 gem 'mini_magick', '~> 4.9.2'
 gem 'nokogiri', '~> 1.10.1'
 gem 'pandoc-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.10.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -253,6 +258,8 @@ GEM
       ffi (>= 0.5.0, < 2)
     rb-readline (0.5.5)
     regexp_parser (1.3.0)
+    request_store (1.4.1)
+      rack (>= 1.4)
     rerun (0.13.0)
       listen (~> 3.0)
     responders (2.4.0)
@@ -368,6 +375,7 @@ DEPENDENCIES
   jquery-ui-rails
   letter_opener
   listen
+  lograge (~> 0.10.0)
   mail
   mini_magick (~> 4.9.2)
   mini_racer

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,9 +52,26 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
+
+  config.lograge.enabled = true
+
+  # Do not log requests to SignImageController#show because whenever we get
+  # *any* request for *any* page, we get many subsequent requests to this
+  # action to serve the images that go with that page. This adds a lot of noise
+  # to the logs.
+  config.lograge.ignore_actions = ['SignImageController#show']
+
+  config.lograge.custom_options = lambda do |event|
+    # 'controller', 'action' and 'format' are already part of the lograge log
+    # line. 'id' can be read from the URL which is already part of the lograge
+    # log line.
+    exceptions = %w(controller action format id)
+
+    {
+      params: event.payload[:params].except(*exceptions)
+    }
+  end
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
Before this change we were logging very verbosely in the `production` env e.g. a single request to  `GET /numbers` generated 462 lines of logging output. This made it **very** difficult to find anything in the logs. 
This change does two things:

1. Change production log level from `debug` to `info`. This does not do much on its own - Rails still logs very verbosely at the `info` level and a single `GET /numbers` generated 450 lines of log output.
2. Install and configure the lograge gem. Lograge (https://github.com/roidrage/lograge) allows us to generate one line of logging output per successful request (stacktraces are still show as they would at the current Rails log level).
3. Tell lograge to ignore requests to `SignImageController#show` because that endpoint is serving all image assets so gets hit many more times than any other endpoint (e.g. `GET /numbers` generates 90 subsequent requests to `SignImageController#show`

The end result is that we get one concise line per requests.

I have an example of the logging output for a single request to `GET /numbers` before this change and after each step above - see https://gist.github.com/eoinkelly/85deb5416b2a8481d84c04a94ecfa301 (I didn't want to inline it here because it is so long)

This change was motivated by my trying to understand a behaviour of the app via the log files. I understand the motivation for wanting to log verbosely to be able to diagnose failures but I think this change is worthwhile because 

1. We have Raygun for error reporting (Errors due to our external dependencies generate a nicely named exception in Raygun since the xmas work landed)
2. Heroku [keeps only 1500 lines of logging](https://devcenter.heroku.com/articles/logging#log-history-limits). 462 lines of log output per page request (including image requests) makes the logs basically useless.

BTW Timber.io logging addon was enabled but the free trial has expired so is no longer helpful. 

