### PR TITLE
Stop Codeclimate checking vendor/

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -40,3 +40,4 @@ exclude_paths:
 - db/
 - spec/
 - bin/
+- vendor/


### PR DESCRIPTION
`vendor/` contains external dependency files which we didn't write (nor would it be appropriate for us to edit) so they shouldn't be included inour Codeclimate issues.

This change should (I hope, it's hard to test beforehand) remove [1443  issues](https://codeclimate.com/github/ODNZSL/nzsl-online/vendor/assets/stylesheets/foundation-icons.scss) from Codeclimate which will let us focus on the ones we can fix :smile: