### PR TITLE
Ask browsers to cache redirects to our canonical hostname for 1 hour

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,7 @@ module NzslOnline
     # More details: https://github.com/tylerhunt/rack-canonical-host
     #
     if ENV['CANONICAL_HOST']
-      config.middleware.insert_before(Rack::Sendfile, Rack::CanonicalHost, ENV['CANONICAL_HOST'], cache_control: 'no-cache')
+      config.middleware.insert_before(Rack::Sendfile, Rack::CanonicalHost, ENV['CANONICAL_HOST'], cache_control: 'max-age=3600')
     end
 
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
1 hour means we get some caching in the browser of this redirect but still have the flexibility to change it quickly if we needed to.

More details: https://github.com/tylerhunt/rack-canonical-host