### PR TITLE
Recover from unexpected cache errors

### DIFF
--- a/app/models/sign.rb
+++ b/app/models/sign.rb
@@ -67,11 +67,16 @@ class Sign # rubocop:disable Metrics/ClassLength
     first(random: 1)
   end
 
-  def self.sign_of_the_day
+  def self.sign_of_the_day # rubocop:disable Metrics/AbcSize
     Rails.cache.fetch('sign-of-the-day', expires_in: 24.hours) do
       Rails.logger.debug('Fetching new random sign from Freelex')
-      first(random: 1)
+      random
     end
+  rescue StandardError => e
+    raise e if Rails.env.test? || Rails.env.development?
+
+    Raygun.track_exception(Exception.new("Recovered from sign-of-the-day cache lookup error. error=#{e.inspect}"))
+    random
   end
 
   def self.paginate(search_query, page_number)

--- a/spec/models/sign_spec.rb
+++ b/spec/models/sign_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe 'Sign', type: :model do
     it 'returns the same sign when called repeatedly' do
       expect(Sign.sign_of_the_day.id).to eq(Sign.sign_of_the_day.id)
     end
+
+    it 'recovers if an exception is rasied by Rails caching' do
+      # given we are not in dev|test env
+      allow(Rails.env).to receive(:development?).and_return(false)
+      allow(Rails.env).to receive(:test?).and_return(false)
+
+      # and Rails caching raises and exception for some reason
+      allow(Rails.cache).to receive(:fetch).and_raise(TypeError)
+
+      # then we expect the method to still return a sign
+      expect(Sign.sign_of_the_day).to be_an_instance_of(Sign)
+    end
   end
 
   describe '.paginate' do


### PR DESCRIPTION
I tried and failed to replicate that cache error I saw on staging. Staging seems to work flawlessly during my testing today and I was never able to replicate the issue locally. To be safe I have created this PR which will recover from cache issues by re-trying the data fetch (without the cache). 

Rails is pretty good at dealing with situations where the cache goes away unexpectedly but just to be safe we are rescuing errors from cache lookups and recovering by fetching the data directly. We also log to Raygun so that these cache errors will be noticed if they are an issue.