### PR TITLE
Adding chrome to travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ sudo: false
 cache:
   bundler: true
   yarn: true
+addons:
+  apt:
+    packages:
+    - chromium-chromedriver
+    - google-chrome-stable
 env:
   global:
     PERCY_TARGET_BRANCH=staging

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,17 +14,10 @@ require "selenium/webdriver"
 require 'capybara-screenshot/rspec'
 require 'percy'
 
-Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu) }
-  )
+require 'webdrivers'
 
-  Capybara::Selenium::Driver.new app,
-    browser: :chrome,
-    desired_capabilities: capabilities
-end
-
-Capybara.javascript_driver = :headless_chrome
+Capybara.default_driver = :selenium_chrome_headless
+Capybara.javascript_driver = :selenium_chrome_headless
 
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
Fixes errors with chrome on travis

```
     3.1) Failure/Error: before { visit sign_path(id: sign_id) }
          Selenium::WebDriver::Error::UnknownError:
            unknown error: Chrome failed to start: exited abnormally
              (unknown error: DevToolsActivePort file doesn't exist)
              (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
          # #0 0x559b476a4299 <unknown>
          # ./spec/features/signs_spec.rb:11:in `block (4 levels) in <top (required)>'
```