### PR TITLE
Trial skylight.io application performance monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem 'faraday_middleware'
 # logins
 gem 'devise'
 
+# Application performance monitoring
+gem 'skylight'
+
 group :assets do
   gem 'coffee-rails'
   gem 'sass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    skylight (4.1.2)
+      skylight-core (= 4.1.2)
+    skylight-core (4.1.2)
+      activesupport (>= 4.2.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -412,6 +416,7 @@ DEPENDENCIES
   rubocop-performance
   sass-rails
   simplecov
+  skylight
   uglifier
   videojs_rails
   webdrivers

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,13 @@
+---
+# Skylight can take configuration from environment variables. We do that whenever possible because it allows us to:
+#
+# 1. Change settings at runtime.
+# 2. Have different settings in different environments.
+#
+# For example, authentication comes from the `SKYLIGHT_AUTHENTICATION` environment
+# variable. The authentication token should **never** be added to this file.
+# For details, see
+# https://www.skylight.io/support/advanced-setup#setting-authentication-tokens
+#
+# The authentication token for the application.
+# authentication: SEE COMMENT ABOVE


### PR DESCRIPTION
Skylight (https://www.skylight.io) is a nice APM tool, similar in functionality to New Relic. I think it is worth trialling it **alongside** our existing New Relic because:

* We can see 24 hours of data with New Relic. Skylight will allow us to see a lot more history.
* The Skylight agent is very small and fast (written in Rust) so adds very little overhead to the application - my research indicates that it should be fine to run both it and New Relic
* Skylight is free for open source projects. If we find it useful then we can apply to be added to their "open source" plan - this would make our performance data public which I think would ultimately be a good thing because it will allow **all** open source contributors (not just those within Ackama) to find (and hopefully fix) performance issues. https://www.skylight.io/oss has links to some existing OSS projects which use Skylight - you can see the Skylight UI from there too.
* Skylight can be configured through environment variables so we can turn it on/off without redeploying - the `SKYLIGHT_ENABLED=true` env var must be set to enable Skylight - this will allow us to safely trial it in production.

If we find that Skylight covers all the key functionality of New Relic then we should remove the New Relic agent at that stage. I don't recommend us doing that until we have lived with Skylight for at least a few weeks.