### PR TITLE
Create a separate endpoint for downloading PDF version of VocabSheet

### DIFF
--- a/app/controllers/vocab_sheets_controller.rb
+++ b/app/controllers/vocab_sheets_controller.rb
@@ -19,18 +19,15 @@ class VocabSheetsController < ApplicationController
   def show
     set_vocab_sheet_size
 
-    respond_to do |format|
-      format.html do
-        return render :print if params[:print] == 'true'
+    return render :print if params[:print] == 'true'
 
-        render :show
-      end
+    render :show
+  end
 
-      format.pdf do
-        pdf = build_rendered_pdf(html: render_to_string(:print, formats: [:html]))
-        send_file(pdf.file_path, filename: pdf.download_as_filename(@title), type: pdf.mime_type)
-      end
-    end
+  def download_pdf
+    set_vocab_sheet_size
+    pdf = build_rendered_pdf(html: render_to_string(:print, formats: [:html]))
+    send_file(pdf.file_path, filename: pdf.download_as_filename(@title), type: pdf.mime_type)
   end
 
   def update # rubocop:disable Metrics/AbcSize

--- a/app/views/vocab_sheets/show.html.haml
+++ b/app/views/vocab_sheets/show.html.haml
@@ -7,7 +7,7 @@
   .vocab-sheet__download-notice.flash.hide
     = t("vocab_sheet.download_in_progress")
   .vocab-sheet__controls.vocab-sheet__page-controls
-    = orange_submit_button "vocab_sheet.download", {format: :pdf, print: true}, class:"vocab-sheet__page-controls--download"
+    = orange_submit_button "vocab_sheet.download", download_pdf_vocab_sheet_path, class:"vocab-sheet__page-controls--download"
     = orange_submit_button "vocab_sheet.print", {print: true}
     = form_tag vocab_sheet_path, method: :delete, class: "" do
       = orange_submit_button "vocab_sheet.delete"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,10 @@ NzslOnline::Application.routes.draw do
   resources :feedback, only: [:create]
 
   resource :vocab_sheet, only: %i[show destroy update] do
+    member do
+      get :download_pdf
+    end
+
     resources :items, only: %i[create destroy update] do
       collection do
         post 'reorder'

--- a/spec/controllers/vocab_sheets_controller_spec.rb
+++ b/spec/controllers/vocab_sheets_controller_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe VocabSheetsController, type: :controller do
     it { expect(response).to have_http_status(:ok) }
   end
 
+  describe '#download_pdf' do
+    before { get :download_pdf }
+
+    it { expect(response).to have_http_status(:ok) }
+  end
+
   describe '#update' do
     before do
       allow_any_instance_of(Browser::Generic)


### PR DESCRIPTION
We want a separate endpoint because we want to see PDF generation separately in our APM (currently New Relic). PDF rendering is slow and masks any issues with rendering the vocab sheet as HTML.

A side effect of this change is that it fixes issue #661 because the URL is changing from `/vocab_sheet.pdf` to `/vocab_sheet/download_pdf` which should make CloudFlare do the right thing out of the box. Currently there is a Cloudflare page rule telling it to ignore .pdf assets but I will remove that once this patch proves itself.