### PR TITLE
Cache VocabSheet#items to mitigate performance regression

### DIFF
--- a/app/models/vocab_sheet.rb
+++ b/app/models/vocab_sheet.rb
@@ -89,7 +89,7 @@ class VocabSheet < ApplicationRecord
 
     new_raw_items = []
 
-    item_ids.each do |id|
+    item_ids.uniq.each do |id|
       new_raw_items << raw_item_attrs.find { |item| item['id'] == id }
     end
 

--- a/app/models/vocab_sheet.rb
+++ b/app/models/vocab_sheet.rb
@@ -4,6 +4,8 @@
 # A "sheet" of items (signs) saved by a user
 #
 class VocabSheet < ApplicationRecord
+  after_save :clear_items_cache
+
   ##
   # @param item [Item] The item you wish to add
   # @return [Boolean] true on success, false on failure
@@ -40,7 +42,21 @@ class VocabSheet < ApplicationRecord
   # @return [Array<Item>] array of items
   #
   def items
-    raw_item_attrs.map { |item_attrs| Item.new(item_attrs) }
+    # Having no items is a very common case (every requests for users who don't
+    # have vocab sheets will be in this situation) so we bail early (and hence
+    # quickly) if that is the case.
+    return [] if raw_item_attrs.empty?
+
+    # It is common for controllers/views to call this method repeatedly in
+    # generating the response to a single request. Creating new Item objects is
+    # expensive because it involves a request to Freelex to fill in all the
+    # attributes. For these reasons, we cache the items created. The cache is
+    # used within a single request.
+    if raw_item_attrs_changed? || @cached_items.nil?
+      @cached_items = raw_item_attrs.map { |item_attrs| Item.new(item_attrs) }
+    end
+
+    @cached_items
   end
 
   ##
@@ -100,6 +116,10 @@ class VocabSheet < ApplicationRecord
   end
 
   private
+
+  def clear_items_cache
+    @cached_items = nil
+  end
 
   def find_item_by(id:)
     item_attrs = raw_item_attrs.find { |raw_item| raw_item['id'] == id }

--- a/spec/models/vocab_sheet_spec.rb
+++ b/spec/models/vocab_sheet_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe VocabSheet, type: :model do
     context 'When there is an item in the VocabSheet' do
       it 'reorders the items as expected' do
         original_order = [item.id, item_2.id]
-        new_order = [item_2.id, item_2.id]
+        new_order = [item_2.id, item.id]
 
         subject.add_item(item)
         subject.add_item(item_2)


### PR DESCRIPTION
When we stopped implementing VocabSheet#items with an ActiveRecord relation
we stopped getting the benefit of the various layers of caching that AR
does for us. This caused a performance regression because

1. VocabSheet#items is called multiple times per request if the user has
  created a vocab sheet.
2. Every call to VocabSheet#items was hitting Freelex once for each item
   (So N items in a vocab sheet would result in N request to Freelex)

This change mitigates that performance regression by caching the items for
use later in generating the same response. It makes use of the ActiveRecord
`*_changed?` methods introduced in Rails 5.

I was able to track this down because Skylight showed we were making multiple requests to Freelex triggered by the views.  

I considered caching these item objects in memcache (via `Rails.cache`) but we only have 30MB of cache available and I think that items would probably exhaust that quickly.