### PR TITLE
Fix one bug and performance improvements by refactoring

### DIFF
--- a/app/controllers/sign_image_controller.rb
+++ b/app/controllers/sign_image_controller.rb
@@ -18,7 +18,7 @@ class SignImageController < ApplicationController
   private
 
   def filename_param
-    return sign_image_params[:filename] if %r{^[\d]+\/[a-zA-z\-0-9]+\.png$} =~ sign_image_params[:filename]
+    return sign_image_params[:filename] if %r{^[\d]+\/[a-zA-z\-0-9]+\.png$}.match?(sign_image_params[:filename])
 
     raise 'Invalid filename'
   end

--- a/app/models/sign_menu.rb
+++ b/app/models/sign_menu.rb
@@ -1,88 +1,143 @@
 # frozen_string_literal: true
 
-class SignMenu
-  def self.handshapes
+class SignMenu # rubocop:disable Metrics/ClassLength
+  HANDSHAPES = [
     [
-      [['1.1.1', '1.1.2', '1.1.3'], ['1.2.1', '1.2.2'], ['1.3.1', '1.3.2'], ['1.4.1']],
-      [['2.1.1', '2.1.2'], ['2.2.1', '2.2.2'], ['2.3.1', '2.3.2', '2.3.3'], ['8.1.1', '8.1.2', '8.1.3']],
-      [['3.1.1'], ['3.2.1'], ['3.3.1'], ['3.4.1', '3.4.2'], ['3.5.1', '3.5.2']],
-      [['4.1.1', '4.1.2'], ['4.2.1', '4.2.2'], ['4.3.1', '4.3.2']],
-      [['5.1.1', '5.1.2'], ['5.2.1'], ['5.3.1', '5.3.2'], ['5.4.1']],
-      [['6.1.1', '6.1.2', '6.1.3', '6.1.4'], ['6.2.1', '6.2.2', '6.2.3', '6.2.4'], ['6.3.1', '6.3.2'],
-       ['6.4.1', '6.4.2'], ['6.5.1', '6.5.2'], ['6.6.1', '6.6.2']],
-      [['7.1.1', '7.1.2', '7.1.3', '7.1.4'], ['7.2.1'], ['7.3.1', '7.3.2', '7.3.3'], ['7.4.1', '7.4.2']]
+      ['1.1.1', '1.1.2', '1.1.3'],
+      ['1.2.1', '1.2.2'],
+      ['1.3.1', '1.3.2'],
+      ['1.4.1']
+    ],
+    [
+      ['2.1.1', '2.1.2'],
+      ['2.2.1', '2.2.2'],
+      ['2.3.1', '2.3.2', '2.3.3'],
+      ['8.1.1', '8.1.2', '8.1.3']
+    ],
+    [
+      ['3.1.1'],
+      ['3.2.1'],
+      ['3.3.1'],
+      ['3.4.1', '3.4.2'],
+      ['3.5.1', '3.5.2']
+    ],
+    [
+      ['4.1.1', '4.1.2'],
+      ['4.2.1', '4.2.2'],
+      ['4.3.1', '4.3.2']
+    ],
+    [
+      ['5.1.1', '5.1.2'],
+      ['5.2.1'],
+      ['5.3.1', '5.3.2'],
+      ['5.4.1']
+    ],
+    [
+      ['6.1.1', '6.1.2', '6.1.3', '6.1.4'],
+      ['6.2.1', '6.2.2', '6.2.3', '6.2.4'],
+      ['6.3.1', '6.3.2'],
+      ['6.4.1', '6.4.2'],
+      ['6.5.1', '6.5.2'],
+      ['6.6.1', '6.6.2']
+    ],
+    [
+      ['7.1.1', '7.1.2', '7.1.3', '7.1.4'],
+      ['7.2.1'],
+      ['7.3.1', '7.3.2', '7.3.3'],
+      ['7.4.1', '7.4.2']
     ]
+  ].freeze
+
+  LOCACTIONS = [
+    ['1.1.In front of body', '2.2.In front of face'],
+    ['3.3.Head', '3.4.Top of Head', '3.5.Eyes', '3.6.Nose', '3.7.Ear', '3.8.Cheek', '3.9.Lower Head'],
+    ['4.0.Body', '4.10.Neck/Throat', '4.11.Shoulders', '4.12.Chest', '4.13.Abdomen', '4.14.Hips/Pelvis/Groin', '4.15.Upper Leg'], # rubocop:disable Metrics/LineLength
+    ['5.0.Arm', '5.16.Upper Arm', '5.17.Elbow', '5.18.Lower Arm'],
+    ['6.0.Hand', '6.19.Wrist', '6.20.Fingers/Thumb', '6.21.Palm of Hand', '6.22.Back of Hand', '6.23.Blades of Hand']
+  ].freeze
+
+  LOCATION_GROUPS = [
+    '1.1.In front of body',
+    '2.2.In front of face',
+    '3.3.Head',
+    '4.0.Body',
+    '5.0.Arm',
+    '6.0.Hand'
+  ].freeze
+
+  USAGE_TAGS = [
+    ['archaic',   1],
+    ['informal',  4],
+    ['neologism', 2],
+    ['obscene',   3],
+    ['rare',      5]
+  ].freeze
+
+  TOPIC_TAGS = [
+    ['Actions and activities',                    5],
+    ['Animals',                                   7],
+    ['Body and appearance',                       9],
+    ['Clothes',                                   10],
+    ['Colours',                                   11],
+    ['Communication and cognition',               6],
+    ['Computers',                                 48],
+    ['Countries and cities',                      21],
+    ['Deaf-related',                              12],
+    ['Direction, location and spatial relations', 13],
+    ['Education',                                 17],
+    ['Emotions',                                  18],
+    ['Events and celebrations',                   14],
+    ['Family',                                    20],
+    ['Food and drink',                            16],
+    ['Government and politics',                   22],
+    ['Health',                                    23],
+    ['House and garden',                          8],
+    ['Idioms and phrases',                        24],
+    ['Language and Linguistics',                  45],
+    ['Law and crime',                             25],
+    ['Maori culture and concepts',                26],
+    ['Materials',                                 27],
+    ['Maths',                                     47],
+    ['Miscellaneous',                             44],
+    ['Money',                                     28],
+    ['Nationality and ethnicity',                 51],
+    ['Nature and environment',                    19],
+    ['New Zealand place names',                   50],
+    ['Numbers',                                   29],
+    ['People and relationships',                  46],
+    ['Places',                                    30],
+    ['Play and toys',                             49],
+    ['Pronouns',                                  31],
+    ['Qualities, description and comparison',     33],
+    ['Quantity and measure',                      34],
+    ['Questions',                                 35],
+    ['Religions',                                 32],
+    ['Science',                                   38],
+    ['Sex and sexuality',                         36],
+    ['Sports, recreation and hobbies',            37],
+    ['Time',                                      39],
+    ['Travel and transportation',                 40],
+    ['Weather',                                   41],
+    ['Work',                                      42]
+  ].freeze
+
+  def self.handshapes
+    HANDSHAPES
   end
 
   def self.locations
-    [['1.1.In front of body', '2.2.In front of face'],
-     ['3.3.Head', '3.4.Top of Head', '3.5.Eyes', '3.6.Nose', '3.7.Ear', '3.8.Cheek', '3.9.Lower Head'],
-     ['4.0.Body', '4.10.Neck/Throat', '4.11.Shoulders', '4.12.Chest', '4.13.Abdomen', '4.14.Hips/Pelvis/Groin',
-      '4.15.Upper Leg'],
-     ['5.0.Arm', '5.16.Upper Arm', '5.17.Elbow', '5.18.Lower Arm'],
-     ['6.0.Hand', '6.19.Wrist', '6.20.Fingers/Thumb', '6.21.Palm of Hand', '6.22.Back of Hand', '6.23.Blades of Hand']]
+    LOCACTIONS
   end
 
   def self.location_groups
-    # The first row and the first of each row.
-    SignMenu.locations.map.with_index { |r, i| i.zero? ? r : r[0] }.flatten
+    LOCATION_GROUPS
   end
 
   def self.usage_tags
-    [['archaic',   1],
-     ['informal',  4],
-     ['neologism', 2],
-     ['obscene',   3],
-     ['rare',      5]]
+    USAGE_TAGS
   end
 
-  def self.topic_tags # rubocop:disable Metrics/MethodLength
-    [
-      ['Actions and activities',                     5],
-      ['Animals',                                    7],
-      ['Body and appearance',                        9],
-      ['Clothes',                                   10],
-      ['Colours',                                   11],
-      ['Communication and cognition', 6],
-      ['Computers', 48],
-      ['Countries and cities', 21],
-      ['Deaf-related',                              12],
-      ['Direction, location and spatial relations', 13],
-      ['Education',                                 17],
-      ['Emotions',                                  18],
-      ['Events and celebrations',                   14],
-      ['Family',                                    20],
-      ['Food and drink',                            16],
-      ['Government and politics',                   22],
-      ['Health',                                    23],
-      ['House and garden', 8],
-      ['Idioms and phrases',                        24],
-      ['Language and Linguistics',                  45],
-      ['Law and crime',                             25],
-      ['Maori culture and concepts',                26],
-      ['Materials',                                 27],
-      ['Maths',                                     47],
-      ['Miscellaneous',                             44],
-      ['Money',                                     28],
-      ['Nationality and ethnicity', 51],
-      ['Nature and environment', 19],
-      ['New Zealand place names', 50],
-      ['Numbers',                                   29],
-      ['People and relationships',                  46],
-      ['Places',                                    30],
-      ['Play and toys', 49],
-      ['Pronouns',                                  31],
-      ['Qualities, description and comparison',     33],
-      ['Quantity and measure',                      34],
-      ['Questions',                                 35],
-      ['Religions',                                 32],
-      ['Science',                                   38],
-      ['Sex and sexuality',                         36],
-      ['Sports, recreation and hobbies',            37],
-      ['Time',                                      39],
-      ['Travel and transportation',                 40],
-      ['Weather',                                   41],
-      ['Work',                                      42]
-    ]
+  def self.topic_tags
+    TOPIC_TAGS
   end
 end

--- a/app/models/sign_parser.rb
+++ b/app/models/sign_parser.rb
@@ -3,6 +3,32 @@
 class SignParser
   VIDEO_EXAMPLES_TOTAL = 4
 
+  BOOLEAN_MAP = {
+    contains_numbers: 'number_incorp',
+    is_fingerspelling: 'fingerspelling',
+    is_directional: 'directional',
+    is_locatable: 'locatable',
+    one_or_two_handed: 'one_or_two_hand'
+  }.freeze
+
+  TAG_MAP = {
+    age_groups: 'VARIATIONAGE',
+    gender_groups: 'VARIATIONGENDER',
+    hint: 'hint',
+    usage: 'usage',
+    usage_notes: 'essay',
+    related_to: 'RELATEDTO',
+    gloss_main: 'glossmain',
+    gloss_secondary: 'glosssecondary',
+    gloss_minor: 'glossminor',
+    gloss_maori: 'glossmaori',
+    drawing: 'ASSET picture',
+    handshape: 'handshape',
+    location_name: 'location',
+    word_classes: 'SECONDARYWORDCLASS',
+    inflection: 'INFLECTION'
+  }.freeze
+
   def initialize(data)
     @data = data
   end
@@ -35,27 +61,14 @@ class SignParser
   end
 
   def parse_tags
-    { age_groups: 'VARIATIONAGE', gender_groups: 'VARIATIONGENDER',
-      hint: 'hint', usage: 'usage',
-      usage_notes: 'essay', related_to: 'RELATEDTO',
-      gloss_main: 'glossmain', gloss_secondary: 'glosssecondary',
-      gloss_minor: 'glossminor', gloss_maori:   'glossmaori',
-      drawing: 'ASSET picture', handshape:     'handshape',
-      location_name: 'location', word_classes:  'SECONDARYWORDCLASS',
-      inflection: 'INFLECTION' }.symbolize_keys.each do |key, tag|
+    TAG_MAP.each do |key, tag|
       value = @data.value_for_tag(tag)
       @sign.send("#{key}=", value)
     end
   end
 
   def parse_booleans
-    {
-      contains_numbers: 'number_incorp',
-      is_fingerspelling: 'fingerspelling',
-      is_directional: 'directional',
-      is_locatable: 'locatable',
-      one_or_two_handed: 'one_or_two_hand'
-    }.each do |key, tag|
+    BOOLEAN_MAP.each do |key, tag|
       value = @data.value_for_tag(tag).to_bool
       @sign.send("#{key}=", value)
     end
@@ -71,16 +84,16 @@ class SignParser
                      "#{ASSET_URL}#{@data.value_for_tag("ASSET finalexample#{i}_slow")}"
                    end
 
-      @sign.examples << { transcription: parse_transcription(@data, "videoexample#{i}"),
+      @sign.examples << { transcription: parse_transcription("videoexample#{i}"),
                           translation: @data.value_for_tag("videoexample#{i}translation"),
                           video: "#{ASSET_URL}#{@data.value_for_tag("ASSET finalexample#{i}")}",
                           video_slow: video_slow }
     end
   end
 
-  def parse_transcription(data, tag)
+  def parse_transcription(tag)
     transcription = []
-    data.css(tag).children.each do |item|
+    @data.css(tag).children.each do |item|
       if item.is_a?(Nokogiri::XML::Text)
         transcription += item.content.split(' ')
       else

--- a/app/views/vocab_sheets/show.html.haml
+++ b/app/views/vocab_sheets/show.html.haml
@@ -1,5 +1,3 @@
-- content_for :scripts do
-  \# javascript_include_tag
 - content_for :head do
   = stylesheet_link_tag "smoothness/jquery-ui.css"
 


### PR DESCRIPTION
Moving object literals out of methods into constants mean they only have to be allocated once at Rails boot. Both `SignParser` and `SignMenu` are hit multiple times in rendering requests so there should be a minor performance improvement because of the refactoring.