### PR TITLE
Update ruby version in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,7 +424,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.6.4p104
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
This change was made by running `bundle install` on the new Ruby version.
Heroku deploys fail if Gemfile and Gemfile.lock don't match.