### PR TITLE
Remove deprecated browser detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'pandoc-ruby'
 gem 'whenever'
 
 gem 'autoprefixer-rails'
-gem 'browser'
 gem 'ckeditor_rails'
 gem 'dalli'
 gem 'foundation-rails', '~> 6.6.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,6 @@ GEM
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     brakeman (4.8.1)
-    browser (3.0.3)
     builder (3.2.4)
     bundle-audit (0.1.0)
       bundler-audit
@@ -364,7 +363,6 @@ DEPENDENCIES
   autoprefixer-rails
   bootsnap (>= 1.1.0)
   brakeman
-  browser
   bundle-audit
   capybara
   capybara-screenshot

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,10 +4,8 @@ class ApplicationController < ActionController::Base
   include BasicAuthHelper
 
   protect_from_forgery with: :exception
-  require 'browser'
   layout :layout_by_resource
 
-  before_action :check_browser_support
   before_action :staging_http_auth
 
   private
@@ -18,14 +16,6 @@ class ApplicationController < ActionController::Base
 
   def layout_by_resource
     devise_controller? ? 'admin' : 'application'
-  end
-
-  def setup_browser_rules
-    Browser.modern_rules.clear
-    Browser.modern_rules << ->(b) { b.chrome? && b.version.to_i >= 55 }
-    Browser.modern_rules << ->(b) { b.firefox? && b.version.to_i >= 51 }
-    Browser.modern_rules << ->(b) { b.safari? && b.version.to_i >= 9 }
-    Browser.modern_rules << ->(b) { b.ie? && b.version.to_i >= 10 }
   end
 
   def find_or_create_vocab_sheet
@@ -71,15 +61,6 @@ class ApplicationController < ActionController::Base
   end
 
   protected
-
-  def check_browser_support
-    setup_browser_rules
-    return if browser.modern?
-
-    flash[:error] = %(Your browser is not supported. This may mean that some features of NZSL Online will
-                      not display properly. <a href="https://updatemybrowser.org/"> Would you like to
-                      upgrade your browser? </a>).html_safe
-  end
 
   def staging_http_auth
     return unless staging_env?

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,6 +21,9 @@
     = print_stylesheet_tag params[:print]
     %link{href: "https://fonts.googleapis.com/css?family=Montserrat:300,400,500&display=swap", :rel => "stylesheet"}/
   %body.row
+    /[if lte IE 9]
+      %div{style: 'font-size: 150%; font-weight: bold; padding: 1em; background-color: red; color: white; display: block;'}
+        Sorry, your browser is not supported. This means that some features of NZSL Online will not work correctly.
     = render partial: "shared/google_tag_manager_body"
     .visuallyhidden
       %a{href: "#content"} Skip to Content

--- a/spec/controllers/vocab_sheets_controller_spec.rb
+++ b/spec/controllers/vocab_sheets_controller_spec.rb
@@ -24,12 +24,6 @@ RSpec.describe VocabSheetsController, type: :controller do
   end
 
   describe '#update' do
-    before do
-      allow_any_instance_of(Browser::Generic)
-        .to receive(:modern?)
-        .and_return(true)
-    end
-
     context 'new vocab sheet' do
       before { patch :update, params: valid_attributes }
 
@@ -67,12 +61,6 @@ RSpec.describe VocabSheetsController, type: :controller do
     let(:valid_request) { delete :destroy, params: { id: vocab_sheet.id } }
     let(:invalid_request) do
       delete :destroy, params: { id: vocab_sheet.id + 100 }
-    end
-
-    before do
-      allow_any_instance_of(Browser::Generic)
-        .to receive(:modern?)
-        .and_return(true)
     end
 
     context 'successful deletion' do


### PR DESCRIPTION
Most of the browser detection that was happening no longer applies - the
only detection that is still relevant is checking for IE 9 and older.

This change does this with a conditional comment instead of trying to
do browser detection in Rails.