### PR TITLE
Force yarn to resolve `minimist` to patched `1.2.x` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "sass-lint": "./node_modules/.bin/sass-lint -v",
     "eslint": "./node_modules/.bin/eslint ."
   },
+  "resolutions": {
+    "sass-lint/gonzales-pe-sl/minimist": "^1.2.x"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ODNZSL/nzsl-online.git"

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,15 +100,6 @@
     chalk "^2.4.2"
     tslib "^1.9.3"
 
-"@oclif/parser@^3.8.3":
-  version "3.8.4"
-  resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.4.tgz#1a90fc770a42792e574fb896325618aebbe8c9e4"
-  integrity sha512-cyP1at3l42kQHZtqDS3KfTeyMvxITGwXwH1qk9ktBYvqgMp5h4vHT+cOD74ld3RqJUOZY/+Zi9lb4Tbza3BtuA==
-  dependencies:
-    "@oclif/linewrap" "^1.0.0"
-    chalk "^2.4.2"
-    tslib "^1.9.3"
-
 "@oclif/plugin-help@^2":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-2.2.3.tgz#b993041e92047f0e1762668aab04d6738ac06767"
@@ -752,7 +743,7 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0:
+debug@^3.0.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2026,12 +2017,7 @@ minimatch@^3.0.4, minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@1.1.x:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
-  integrity sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=
-
-minimist@^1.2.5:
+minimist@1.1.x, minimist@^1.2.5, minimist@^1.2.x:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==


### PR DESCRIPTION
Ideally `sass-lint` should be removed since it's deprecated, but for now this will address the audit advisory.

At Ackama we've been replacing `sass-lint` with `stylelint`, but it doesn't have a direct 1:1 rule parity.