### PR TITLE
Hide 'Change label' button again on vocab sheet page

### DIFF
--- a/app/assets/javascripts/vocab_sheet.js
+++ b/app/assets/javascripts/vocab_sheet.js
@@ -4,6 +4,8 @@ $(document).ready(function() {
   var setup_vocab_sheet_page = function() {
     // Reorder vocab sheet items
     if ($('ul#vocab_sheet').length) {
+      $('ul#vocab_sheet .button, .vocab_sheet_name .button').hide();
+
       if (!document.printView) {
         $('ul#vocab_sheet').sortable({
           containment: 'parent',


### PR DESCRIPTION
This change adds back in a line required to hide labels on the vocab sheet. The line was removed as part of PR #982

I'm not actually sure whether that button should be even in the DOM anymore but changing that is probably quite a time consuming process of re-testing a bunch of the UI (it seems like we don't have great test coverage there) so I'm just going to revert the line that caused the issue.