### PR TITLE
CCSD-1257/restore foundation back to public frontend

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,6 +9,7 @@
 //= require jquery-ui/widgets/menu
 
 //= require modernizr
+//= require foundation
 
 //= require base
 //= require vocab_bar
@@ -23,3 +24,7 @@
 //= require auto_expand_textarea
 //= require search-result-load-in
 //= require search-vocab
+
+$(function() {
+  $(document).foundation();
+});


### PR DESCRIPTION
#977 removed Foundation from the public facing site, but it's used [here](https://github.com/ODNZSL/nzsl-online/blob/staging/app/assets/javascripts/custom_play_button.js#L21) to check if the application is being viewed on mobile, *after* checking with `Modernizr` if the apps on a touch device (meaning the error doesn't occur on desktop).

Currently the application will error while viewing pages on mobile, preventing the site from being used properly, so I've taken the safe route of just restoring Foundation on the frontend, but ideally this check should be either removed or replaced with one decoupled from the rest of the Foundation code base to avoid pulling in the entire bundle just for that check.