### PR TITLE
use sassc-rails gem instead of deprecated sass-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem 'devise'
 gem 'newrelic_rpm'
 gem 'skylight'
 
-gem 'sass-rails'
+gem 'sassc-rails'
 gem 'uglifier'
 
 # Bundle gems for the local environment. Make sure to

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,8 +316,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.3.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -431,7 +429,7 @@ DEPENDENCIES
   rubocop (~> 0.87.1)
   rubocop-performance
   rubocop-rails
-  sass-rails
+  sassc-rails
   simplecov
   skylight
   uglifier


### PR DESCRIPTION
The ruby implementation of sass reached its end of life quite a while ago https://github.com/rails/sass-rails/issues/420

Since then `sass-rails` has been updated to 6.0 but now wraps its c implementation equivalent `sassc-rails`.
There are still some gems that have a dependancy on sass-rails (although none in this particular repo) but requiring `sassc-rails` directly should help bundler to do a little bit less work resolving versions if any gems with that dependancy are introduced in the future and helps to be a bit more explicit about what this app is actually dependant on.