### PR TITLE
Upgrade rubocop, rubocop-performance, rubocop-rails

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,7 +4,7 @@ engines:
     enabled: false
   rubocop:
     enabled: true
-    channel: rubocop-0-87
+    channel: rubocop-0-90
   sass-lint:
     enabled: true
   shellcheck:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,7 +82,7 @@ Metrics/MethodLength:
   Max: 20
 
 Metrics/AbcSize:
-  Max: 22
+  Max: 26
 
 Metrics/PerceivedComplexity:
   Max: 12
@@ -132,15 +132,107 @@ Lint/DeprecatedOpenSSLConstant:
 Style/SlicingWithRange:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintmixedregexpcapturetypes
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: true
+
+Rails/FindById:
+  Enabled: true
+
+Rails/Inquiry:
+  Enabled: true
+
+Rails/MailerName:
+  Enabled: true
+
+Rails/MatchRoute:
+  Enabled: true
+
+Rails/NegateInclude:
+  Enabled: true
+
+Rails/Pluck:
+  Enabled: true
+
+Rails/PluckInWhere:
+  Enabled: true
+
+Rails/RenderInline:
+  Enabled: true
+
+Rails/RenderPlainText:
+  Enabled: true
+
+Rails/ShortI18n:
+  Enabled: true
+
+Rails/WhereExists:
+  Enabled: true
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: true
+
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantregexpcharacterclass
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
+
+Style/ArrayCoercion:
+  Enabled: true
+
+Style/CaseLikeIf:
+  Enabled: true
+
+Style/ExplicitBlockArgument:
+  Enabled: true
+
+Style/GlobalStdStream:
+  Enabled: true
+
+Style/HashAsLastArrayItem:
+  Enabled: true
+
+Style/HashLikeCase:
+  Enabled: true
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+
 Style/RedundantRegexpCharacterClass:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantregexpescape
 Style/RedundantRegexpEscape:
   Enabled: true
 
+Style/SingleArgumentDig:
+  Enabled: true
+
+Style/StringConcatenation:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ group :development, :test do
   ##
   # We want to use the same version of rubocop as Codeclimate does - see
   # .codeclimate.yml and https://docs.codeclimate.com/docs/rubocop
-  gem 'rubocop', '~> 0.89.1', require: false
+  gem 'rubocop', '~> 0.90.0', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ group :development, :test do
   ##
   # We want to use the same version of rubocop as Codeclimate does - see
   # .codeclimate.yml and https://docs.codeclimate.com/docs/rubocop
-  gem 'rubocop', '~> 0.87.1', require: false
+  gem 'rubocop', '~> 0.89.1', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,7 +292,7 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
-    rubocop (0.89.1)
+    rubocop (0.90.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
@@ -426,7 +426,7 @@ DEPENDENCIES
   rerun
   responders (~> 3.0)
   rspec-rails
-  rubocop (~> 0.89.1)
+  rubocop (~> 0.90.0)
   rubocop-performance
   rubocop-rails
   sassc-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,20 +292,20 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
-    rubocop (0.87.1)
+    rubocop (0.89.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.7)
       rexml
-      rubocop-ast (>= 0.1.0, < 1.0)
+      rubocop-ast (>= 0.3.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.2.0)
-      parser (>= 2.7.0.1)
-    rubocop-performance (1.7.0)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
+    rubocop-performance (1.7.1)
       rubocop (>= 0.82.0)
-    rubocop-rails (2.7.0)
+    rubocop-rails (2.7.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
@@ -426,7 +426,7 @@ DEPENDENCIES
   rerun
   responders (~> 3.0)
   rspec-rails
-  rubocop (~> 0.87.1)
+  rubocop (~> 0.89.1)
   rubocop-performance
   rubocop-rails
   sassc-rails

--- a/app/services/search_query_sanitization_service.rb
+++ b/app/services/search_query_sanitization_service.rb
@@ -2,7 +2,7 @@
 
 class SearchQuerySanitizationService
   ANYTHING_EXCEPT_NUMBERS_AND_SPACE_REGEX = /[^[[:digit:]] ]+/.freeze
-  ANYTHING_EXCEPT_NUMBERS_SPACE_PERIOD_REGEX = /[^[[:digit:]]\. ]+/.freeze
+  ANYTHING_EXCEPT_NUMBERS_SPACE_PERIOD_REGEX = /[^[[:digit:]]. ]+/.freeze
   ANYTHING_EXCEPT_NUMBERS_REGEX = /[^[[:digit:]]]+/.freeze
   ANYTHING_EXCEPT_LETTERS_NUMBERS_HYPHEN_SPACE_REGEX = /[^[[:alnum:]] -]+/.freeze
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -133,7 +133,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/spec/models/sign_spec.rb
+++ b/spec/models/sign_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Sign', type: :model do
       sign = Sign.new
       required_attributes.each do |att|
         expect(sign.respond_to?(att)).to eq(true)
-        expect(sign.respond_to?(att.to_s + '=', '')).to eq(true)
+        expect(sign.respond_to?("#{att}=", '')).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Rubocop upgrades always come with new lints and changes to existing lints.
This change upgrades rubocop (and associated gems) and sets values for
the new lints. Default settings are used whenever possible except where
they would require too many changes to the codebase. These exceptions are:

* Rubocop seems to have changed how it calculates AbcSize so we adjust the
  size from 22 to 26 to keep our current code passing
* Style/OptionalBooleanParameter is disabled because the existing code makes
  extensive use of non-optional default params.

