### PR TITLE
ci: use brakeman gem from `Gemfile`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,10 @@ jobs:
       - name: Install Ruby (version given by .ruby-version) and Bundler
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: false
+          bundler-cache: true
 
       - name: Run Ruby static analysis
-        run: |
-          gem install --no-document brakeman
-          brakeman --run-all-checks --exit-on-warn --format plain .
+        run: bundle exec brakeman --run-all-checks --exit-on-warn --format plain .
 
   eslint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I believe this should fix the sudden CI failings we're getting due to Brakeman, as it'll be using v5 rather than what we have in our `Gemfile`.