### PR TITLE
ci: tell `renovate` to ignore `puppeteer`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "pinVersions": false
+  "extends": ["config:base"],
+  "pinVersions": false,
+  "ignoreDeps": ["puppeteer"]
 }


### PR DESCRIPTION
This matches with the ignore we added in #1210 for dependabot.