### PR TITLE
Fix issue causing app to crash if Freelex unavailable.

### DIFF
--- a/app/models/sign.rb
+++ b/app/models/sign.rb
@@ -192,7 +192,7 @@ class Sign
       Rails.logger.warn(msg)
       Raygun.track_exception(e)
 
-      []
+      [0, []]
     end
 
     # @param [Hash] search_query_params


### PR DESCRIPTION
Sign#search was not returning the correct value in the case where an
exception was raised talking to Freelex.