### PR TITLE
fix: track freelex status and show different error message if it errors

### DIFF
--- a/app/controllers/signs_controller.rb
+++ b/app/controllers/signs_controller.rb
@@ -8,7 +8,7 @@ class SignsController < ApplicationController
   def search
     search_query = SearchQuerySanitizationService.new.sanitize_for_standard_search(permitted_params)
     @page_number = permitted_params[:p].present? ? permitted_params[:p].to_i : 1
-    @results_total, @signs = Sign.paginate(search_query, @page_number)
+    @results_total, @signs, @freelex_errored = Sign.paginate(search_query, @page_number)
     @query = search_query
     @pagination_html = SignPaginationService.new(current_page_number: @page_number,
                                                  total_num_results: @results_total,

--- a/app/views/signs/search.html.haml
+++ b/app/views/signs/search.html.haml
@@ -1,8 +1,11 @@
 = render partial: 'shared/vocab_sheet', locals: { sheet: @sheet }
 .search-result-banner.small-12.text-center
   %h2
-    = @results_total
-    search results for #{display_search_term}
+    - if @freelex_errored
+      Search is currently unavailable
+    - else
+      = @results_total
+      search results for #{display_search_term}
 .search-results__container.text-center.small-12.small-centered.medium-7.large-8.xlarge-9
   - @signs.each do |sign|
     .search-results__card


### PR DESCRIPTION
I figured this would be a bit safer than using `-1`, given that the test suite can't currently run with Freelex down.
There's probably more use cases for this third "error state" value that we could explore after Freelex has been restored.

For now I've not changed any tests since they're failing because of Freelex anyway; we should pick that up after service has been restored.