### PR TITLE
ci: remove code climate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,6 @@ jobs:
         run: |
           yarn install
 
-      - name: Setup CodeClimate Reporter
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter before-build
-
       - name: Prepare database for testing
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/nzsl_test
@@ -119,7 +113,7 @@ jobs:
         run: |
           bundle exec rails db:prepare
 
-      - name: Run rspec (report results to Percy.io and CodeClimate)
+      - name: Run rspec
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/nzsl_test
           DEVISE_SECRET_KEY: anything
@@ -127,5 +121,4 @@ jobs:
           APP_DOMAIN_NAME: localhost:3000
           APP_PROTOCOL: http
           S3_BUCKET_URL: http://s3-ap-southeast-2.amazonaws.com/dummy-fake/
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        run: bundle exec rspec spec &&  ./cc-test-reporter after-build
+        run: bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,6 @@ group :test do
   gem 'capybara'
   gem 'capybara-screenshot'
   gem 'capybara-selenium'
-  gem 'codeclimate-test-reporter', '~> 1.0.9'
   gem 'database_cleaner'
   gem 'percy-capybara', '~> 4.3.2'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,8 +105,6 @@ GEM
     childprocess (3.0.0)
     chronic (0.10.2)
     climate_control (0.2.0)
-    codeclimate-test-reporter (1.0.9)
-      simplecov (<= 0.13)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
@@ -403,7 +401,6 @@ DEPENDENCIES
   capybara-screenshot
   capybara-selenium
   ckeditor_rails!
-  codeclimate-test-reporter (~> 1.0.9)
   dalli
   database_cleaner
   devise

--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ New Zealand Sign Language Dictionary consists of 3 major units
 * Freelex, an open source project for maintaining the signs lexicon data.
 
 ![Build Status](https://github.com/ODNZSL/nzsl-online/workflows/CI/badge.svg)
-[![Code Climate](https://codeclimate.com/github/ODNZSL/nzsl-online/badges/gpa.svg)](https://codeclimate.com/github/ODNZSL/nzsl-online)
-[![Test Coverage](https://codeclimate.com/github/ODNZSL/nzsl-online/badges/coverage.svg)](https://codeclimate.com/github/ODNZSL/nzsl-online/coverage)
-[![Issue Count](https://codeclimate.com/github/ODNZSL/nzsl-online/badges/issue_count.svg)](https://codeclimate.com/github/ODNZSL/nzsl-online)
 
 ## Browser support
 


### PR DESCRIPTION
Changes to GH secrets for actions means that bots like dependabot need to have credentials setup separately, however we don't have access to the project on CodeClimate so for now am just removing it so that CI can pass.