### PR TITLE
fix: update ruby version in lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,7 +464,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.5
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
For some reason this wasn't updated by dependabot 🤷 