### PR TITLE
Remove the check for duplicate signs in the vocab sheet

### DIFF
--- a/app/models/vocab_sheet.rb
+++ b/app/models/vocab_sheet.rb
@@ -11,8 +11,16 @@ class VocabSheet < ApplicationRecord
   # @return [Boolean] true on success, false on failure
   #
   def add_item(item)
-    # Don't add duplicates
-    return true if raw_item_attrs.any? { |raw_item| raw_item['id'] == item.id }
+    # The customer has requested we do not prune duplicate entries
+    # because one sign can translate to many words
+    # such as pear, peach, and apple, and the vocab sheet can be edited
+    # to differentiate these signs.
+    # Also, some people use the vocab sheets to create running sentences/phrases
+    # - for example, a school is talking about puppies and foals and want to
+    # include the signs 'baby dog' and 'baby horse' on the same sheet,
+    # necessitating two copies of 'baby'
+    # Also, the customer has previously asked that duplicates are removed,
+    # for this and is surprised duplciates are pruned.
 
     raw_item_attrs << convert_to_storable_hash(item)
     save

--- a/spec/models/vocab_sheet_spec.rb
+++ b/spec/models/vocab_sheet_spec.rb
@@ -38,12 +38,13 @@ RSpec.describe VocabSheet, type: :model do
     end
 
     context 'When adding an item which already exists in the VocabSheet' do
-      it 'does not save a duplicate item' do
+      it 'does save a duplicate item' do
         subject.add_item(item)
         subject.add_item(item)
 
-        expect(subject.items.length).to eq(1)
+        expect(subject.items.length).to eq(2)
         expect(subject.items.first.id).to eq(item.id)
+        expect(subject.items.second.id).to eq(item.id)
       end
     end
   end


### PR DESCRIPTION
Remove the check for duplicate signs in the vocab sheet, since Micky asked me to.

From the issue:

Yes, you’ve captured the issue well. People can edit the glosses as you say, so they can avoid having identical entries on the sheet. Also, some people use the vocab sheets to create running sentences / phrases – for example, a school is talking about puppies and foals and want to include the signs ‘baby dog’ and ‘baby horse’ on the same sheet, necessitating two copies of ‘baby’.  

I remember this issue coming up a few years ago during the vocab sheet improvements work and requesting that duplicates were allowed on the sheet. I think that worked at the time, so not sure when this change came in. If it’s easy to reverse it, that would be great. 