### PR TITLE
build: lock node major version to v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,10 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v2
       - name: Install NodeJS
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: '16'
+          cache: 'yarn'
 
       - name: Install required JS packages
         run: yarn install
@@ -75,9 +76,9 @@ jobs:
           sudo apt-get -y install libpq-dev google-chrome-stable
 
       - name: Install NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: '16'
           cache: 'yarn'
 
       - name: Install Ruby (version given by .ruby-version) and Bundler

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/ODNZSL/nzsl-online#readme",
   "engines": {
-    "node": ">=9.10.0",
+    "node": "^16.0.0",
     "yarn": ">=1.3.2"
   },
   "dependencies": {


### PR DESCRIPTION
Currently we fail to build on ubuntu-18 because our node version allows for v18 but that can't compile on ubuntu-18 due to clibs. We can't move to ubuntu-20 yet because that takes us over the 500mb slub limit.

So this pins us to Node 16 which lets us keep deploying. I'll deal with the slug size problem next year.