### PR TITLE
Use native playback speed control for videos

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -1,4 +1,4 @@
-$(function(){
+$(function() {
   var setup = function(){
     setup_ckeditor_video_links();
     setup_videos();
@@ -95,7 +95,7 @@ $(function(){
       $this.hide();
 
       if ($this.hasClass('slow')){
-        playbackRate = 0.25;
+        playbackRate = 0.5;
         $(".button.normal", container).show();
       } else {
         $(".button.slow", container).show();

--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -85,21 +85,26 @@ $(function(){
     }
   };
 
-  var setup_slow_motion_videos = function(){
+  var setup_slow_motion_videos = function() {
     $('.button.normal, .button.slow').click(function(){
-      var show, hide, video;
-      var videos = $(this).closest('.videos');
-      if ($(this).hasClass('normal')){
-        show = 'slow';
-        hide = 'normal';
-      } else if ($(this).hasClass('slow')) {
-        show = 'normal';
-        hide = 'slow';
+      var $this = $(this);
+      var container = $this.parents(".video-container");
+      var videos = container.find("video");
+      var playbackRate = 1.0;
+
+      $this.hide();
+
+      if ($this.hasClass('slow')){
+        playbackRate = 0.25;
+        $(".button.normal", container).show();
+      } else {
+        $(".button.slow", container).show();
       }
-      videos.find("."+hide).toggle(hide);
-      videos.find("."+show).toggle(show);
-      pause_video(hide, videos);
-      play_video(show, videos);
+
+      $.each(videos, function() {
+        this.playbackRate = playbackRate;
+        this.play();
+      });
     });
   };
 

--- a/app/assets/javascripts/custom_play_button.js
+++ b/app/assets/javascripts/custom_play_button.js
@@ -1,4 +1,6 @@
 $(document).ready(function() {
+  var hasPlayButton = true;
+
   adjustVideoControlsToScreenSize();
 
   $(window).resize(function() {
@@ -10,6 +12,12 @@ $(document).ready(function() {
       e.preventDefault();
       videoResponse(this);
     }
+  }).on('play', function(evt) {
+    pauseOtherVideos(evt.target);
+    hasPlayButton && $(evt.target)
+        .closest('.video-container')
+        .children('.play-button')
+        .css('opacity', '0');
   });
 
   $('.play-button').click(function(e) {
@@ -19,47 +27,26 @@ $(document).ready(function() {
 
   function adjustVideoControlsToScreenSize() {
     if (Modernizr.touch && !Foundation.MediaQuery.atLeast('large')) {
+      hasPlayButton = false;
       $('.play-button').hide();
       $('video').each(function() {
         $(this).prop('controls', true);
         $(this).prop('controlsList', 'nodownload');
       });
     } else {
+      hasPlayButton = true;
       $('.play-button').show();
       $(this).prop('controls', false);
     }
   }
 
   function videoResponse(video) {
-    video.paused == true ? playVideo(video) : pauseVideo(video);
-  }
-
-  function playVideo(video) {
-    pauseOtherVideos(video);
-    $(video)
-        .closest('.video-container')
-        .children('.play-button')
-        .css('opacity', '0');
-    $(video)
-        .get(0)
-        .play();
-  }
-
-  function pauseVideo(video) {
-    $(video)
-        .closest('.video-container')
-        .children('.play-button')
-        .css('opacity', '0');
-    $(video)
-        .get(0)
-        .pause();
+    video.paused ? video.play() : video.pause();
   }
 
   function pauseOtherVideos(currentVideo) {
-    $('video').each(function() {
-      if (this != currentVideo) {
-        pauseVideo(this);
-      }
+    $('video').not(currentVideo).each(function() {
+      this.pause();
     });
   }
 });

--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -19,7 +19,8 @@ video {
 }
 
 .videos {
-  .slow {
+  // Hide 'normal' playback speed by default
+  .button.normal {
     display: none;
   }
 

--- a/app/views/signs/show.html.haml
+++ b/app/views/signs/show.html.haml
@@ -28,11 +28,9 @@
     .videos.small-12.medium-5
       .video-container
         %i.fi-play.play-button
-        = videojs_rails sources: { mp4: @sign.video }, class: "main_video video normal", controlsList:"nodownload", controls: true, preload: "metadata", loop: true
-        - if @sign.video_slow.present?
-          = videojs_rails sources: { mp4: @sign.video_slow }, class: "main_video video slow", controls: true, controlsList:"nodownload",  preload: "metadata", loop: true, width: "100%"
-          = play_video_button('signs.show.in_slow_motion', nil, class: 'float-left normal')
-          = play_video_button('signs.show.at_normal_speed', nil, class: 'float-left slow')
+        = videojs_rails sources: { mp4: @sign.video }, class: "main_video video", controlsList:"nodownload", controls: true, preload: "metadata", loop: true
+        = play_video_button('signs.show.in_slow_motion', nil, class: 'float-left slow')
+        = play_video_button('signs.show.at_normal_speed', nil, class: 'float-left normal')
       .glosses-container.glosses.small-12.float-left
         %h2.main_gloss= @sign.gloss_main
         %h2.secondary_gloss= @sign.gloss_secondary
@@ -47,11 +45,9 @@
           .typography.videos
             .video-container
               %i.fi-play.play-button
-              = videojs_rails sources: { mp4: example[:video]}, class: "example_video video normal", controls: true, controlsList:"nodownload noremoteplayback", preload: "metadata"
-              - if example[:video_slow]
-                = videojs_rails sources: { mp4: example[:video_slow] }, class: "example_video video slow", controls: true, controlsList:"nodownload noremoteplayback", preload: "metadata", width: "100%"
-                = play_video_button('signs.show.in_slow_motion', nil, class: 'float-left normal')
-                = play_video_button('signs.show.at_normal_speed', nil, class: 'float-left slow')
+              = videojs_rails sources: { mp4: example[:video]}, class: "example_video video", controls: true, controlsList:"nodownload noremoteplayback", preload: "metadata"
+              = play_video_button('signs.show.in_slow_motion', nil, class: 'float-left slow')
+              = play_video_button('signs.show.at_normal_speed', nil, class: 'float-left normal')
             .small-12.float-left
               %p.secondary_gloss= render_transcription(example[:transcription], @sign.id)
               %h4.translation-gloss


### PR DESCRIPTION
This pull request updates the support for slow motion videos on sign pages to use the HTML video tag's native playbackRate support, rather than relying on a separate slowed-down video file. This has a number of advantages:

1. The dictionary management software no longer needs to maintain and manually encode slow-motion videos for main gloss videos and examples
2. The storage size of videos will be drastically reduced without the need to store slowed-down videos (not half, because not all videos have slow recordings, but a decent amount do)
3. Users only need to load one video, not two

We also have options in the future to vary the playback speed more dynamically, other than just half-speed or full-speed. I also note that while working on this feature, I noticed that we're really not using VideoJS anymore. It actually doesn't even seem to be properly initialised, but we're still depending on this library. It would be good to clean this up sometime to be clear that developers should expect to work with native video tags rather than the VideoJS API.

Video demo, showing main gloss and usage examples being toggled in and out of slow-motion state, and to show that videos without slow-motion continue to work as normal:


https://user-images.githubusercontent.com/292020/171751100-ba0b0197-5614-4848-af57-f98287e818dd.mp4


