### PR TITLE
Update slow playback rate to 60% instead of 50%.

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -95,7 +95,7 @@ $(function() {
       $this.hide();
 
       if ($this.hasClass('slow')){
-        playbackRate = 0.5;
+        playbackRate = 0.6;
         $(".button.normal", container).show();
       } else {
         $(".button.slow", container).show();


### PR DESCRIPTION
This change bumps the slow video playback rate to match the settings of videos that are encoded as slow motion in the dictionary. I eyeballed times and guessed 50% when I first implemented this, but have since checked back with the database administrator to confirm it is actually 60%.