### PR TITLE
chore: remove explicit ruby version in rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,12 @@ require:
   - rubocop-rails
   - rubocop-performance
 
+AllCops:
+  Exclude:
+    - 'vendor/**/*'
+    - 'node_modules/**/*'
+    - 'db/schema.rb'
+
 Rails/WhereNot:
   Enabled: true
 
@@ -150,13 +156,6 @@ Naming/FileName:
   Exclude:
     - Gemfile
     - Gemfile.lock
-
-AllCops:
-  TargetRubyVersion: 2.6
-  Exclude:
-    - 'vendor/**/*'
-    - 'node_modules/**/*'
-    - 'db/schema.rb'
 
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true


### PR DESCRIPTION
I completely missed this in #1486 🤦 