### PR TITLE
Resolve Raygun #162465615499: Handle signs without drawing

### DIFF
--- a/app/views/signs/search.html.haml
+++ b/app/views/signs/search.html.haml
@@ -27,9 +27,10 @@
               .word_gloss.small-12.text-left
                 = sign.word_classes if sign.word_classes.present?
       .card__bottom-row
-        .card__sign-container
-          = link_to sign_url(sign.id), { class: 'drawing grid_drawing js-ga-link-submission', onclick: "_gaq.push(['_trackEvent','Search','Click','#{query_text}-#{sign.id}',#{@signs.find_index(sign) + 1}]);" } do
-            = image_tag sign.picture_url, { class: 'card__drawing-image' }
+        - if sign.picture_url
+          .card__sign-container
+            = link_to sign_url(sign.id), { class: 'drawing grid_drawing js-ga-link-submission', onclick: "_gaq.push(['_trackEvent','Search','Click','#{query_text}-#{sign.id}',#{@signs.find_index(sign) + 1}]);" } do
+              = image_tag sign.picture_url, { class: 'card__drawing-image' }
         .card__button-container
           = link_to sign_url(sign.id), { class: "card__button" } do
             %span.card__button-symbol.card__button-symbol--blue →

--- a/app/views/signs/show.html.haml
+++ b/app/views/signs/show.html.haml
@@ -12,15 +12,17 @@
       .sign_attributes
         = handshape_image @sign.handshape
         = location_image @sign.location
-      = image_tag @sign.picture_url, class: "main-image"
+      - # We still render an image tag in this case to not break the layout
+      = image_tag @sign.picture_url || "", class: "main-image"
       .glosses-container.glosses
         %h2.main_gloss= @sign.gloss_main
         %h2.main_gloss.maori-gloss= @sign.gloss_maori
       .buttons-container
-        = link_to @sign.picture_url, { class: "download-link", "data-sign-id": @sign.id } do
-          %span
-            = image_tag "ui/download-button.svg", class: "card__button download-button"
-          %span.buttons-action  Download Drawing
+        - if @sign.picture_url
+          = link_to @sign.picture_url, { class: "download-link", "data-sign-id": @sign.id } do
+            %span
+              = image_tag "ui/download-button.svg", class: "card__button download-button"
+            %span.buttons-action  Download Drawing
         = link_to "#", { class: "card__button add-to-vocab-btn sign__button--peach", "data-sign-id": @sign.id } do
           %span.icon-container.add-button-icon
             %i.fi-plus

--- a/spec/features/signbank/signs_spec.rb
+++ b/spec/features/signbank/signs_spec.rb
@@ -74,6 +74,19 @@ RSpec.describe 'Signbank: Sign features', type: :system, sign_model_adapter: :si
     expect(page).to have_selector '.secondary_gloss', text: sign.minor
     expect(page).to have_selector '.maori-gloss', text: sign.maori
     expect(page).to have_selector 'video.main_video'
+    expect(page).to have_link 'Download Drawing'
+    expect(page).to have_link 'Add to Vocab Sheet'
+  end
+
+  it 'can view a sign when the sign is missing a drawing' do
+    sign = Signbank::Sign.find('1301').dup
+    sign.id = SecureRandom.uuid # New ID, no picture
+    sign.save!
+    visit sign_path(sign)
+    expect(page).to have_selector '.main_gloss', text: sign.gloss
+    expect(page).not_to have_link 'Download drawing'
+    expect(page).to have_link 'Add to Vocab Sheet'
+    expect(page).to have_selector "img.main-image[src='']"
   end
 
   it "can see a 'sign of the day'" do

--- a/spec/features/signbank/signs_spec.rb
+++ b/spec/features/signbank/signs_spec.rb
@@ -95,13 +95,13 @@ RSpec.describe 'Signbank: Sign features', type: :system, sign_model_adapter: :si
       expect(page).to have_content('Sign of the day')
       # We don't know what the gloss will be ahead of time, but we know the link
       # href to expect
-      expect(page).to have_link(href: %r{^#{Capybara.current_session.server.base_url}/signs/\d+$})
+      expect(page).to have_link(href: %r{/signs/\d+$})
     end
   end
 
   it 'can request a random sign' do
     visit root_path
-    sign_link_matcher = %r{^#{Capybara.current_session.server.base_url}/signs/\d+$}
+    sign_link_matcher = %r{/signs/\d+$}
 
     sign_link = page.find_link(href: sign_link_matcher, match: :first)
     sign_href_a = sign_link['href']

--- a/spec/features/signbank/signs_spec.rb
+++ b/spec/features/signbank/signs_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Signbank: Sign features', type: :feature, sign_model_adapter: :freelex do
+RSpec.describe 'Signbank: Sign features', type: :system, sign_model_adapter: :signbank do
   before { Rails.application.load_seed }
 
   it 'can search for signs', js: true do

--- a/spec/features/topics_spec.rb
+++ b/spec/features/topics_spec.rb
@@ -2,13 +2,8 @@
 
 require 'rails_helper'
 
-describe 'Topics', js: true do
-  let(:sign_id) { '1301' }
-
-  before do
-    SeedDataService.load_all
-    allow(SignModel.resolve).to receive(:random).and_return SignModel.resolve.find(sign_id)
-  end
+describe 'Topics', js: true, sign_model_adapter: :signbank do
+  before { SeedDataService.load_all }
 
   describe 'Actions and Activities' do
     it 'works' do

--- a/spec/models/signbank/sign_of_the_day_spec.rb
+++ b/spec/models/signbank/sign_of_the_day_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Signbank::SignOfTheDay, type: :model do
   describe '#find' do
     it 'fetches a random sign to populate the cache for 24 hours' do
       expect(Signbank::Sign).to receive(:random)
+      # Make sure there isn't already a cache entry
+      Rails.cache.delete(described_class::CACHE_KEY)
       expect(Rails.cache).to receive(:fetch)
         .with(described_class::CACHE_KEY, expires_in: described_class::EXPIRY)
         .and_call_original


### PR DESCRIPTION
We have a sign that is missing a drawing (7200). This sign should not be published, since it doesn't have the requisite content to be considered publishable, but I think it's still worth a patch so that this kind of record doesn't break the page - particularly for search results in which it may inadvertently show up.

When the drawing is missing, we just don't show it:

![image](https://user-images.githubusercontent.com/292020/215985103-023c7315-b218-4363-bb20-e05edf3c5d2c.png)
