### PR TITLE
NZSL-138: Add a polyfill for cross-origin downloads by downloading as a Blob to link to

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //= require foundation
 
 //= require base
+//= require download-link
 //= require vocab_bar
 //= require vocab_sheet
 //= require search_analytics

--- a/app/assets/javascripts/download-link.js
+++ b/app/assets/javascripts/download-link.js
@@ -1,0 +1,43 @@
+/**
+ * This function 'polyfills' cross-origin file downloads. It does so by fetching
+ * the file as a blob, then creating a a[download] with the blob URL and
+ * clicking it, then removing it from the DOM.
+ *
+ * Since we have a CORS policy allowing fetches to our media bucket, this works
+ * cross-origin, since after fetching, the blob is same-origin.
+ *
+ * It derives the filename to use as the basename of the href URL. This assumes
+ * that the URL has a filename in it, rather than just a path name. If the
+ * basename cannot be derived, 'file' is used as the filename.
+ */
+function initializeDownloadLinks() {
+  $(document).on('click', '.download-link', function(evt) {
+    evt.preventDefault();
+    var link = this;
+    var path_parts = new URL(link.href).pathname.split('/');
+    var filename = path_parts[path_parts.length - 1] || 'file';
+
+    fetch(link.href)
+        .then(function(response) {
+          return response.blob();
+        })
+        .then(function(blob) {
+          var a = document.createElement('a');
+          a.download = filename;
+          a.style.display = 'none';
+          a.href = URL.createObjectURL(blob);
+          a.addEventListener('click', function() {
+            setTimeout(function() {
+              URL.revokeObjectURL(a.href);
+              a.remove();
+            }, 1000);
+          });
+          document.body.append(a);
+          a.click();
+        });
+  });
+}
+
+$(function() {
+  initializeDownloadLinks();
+});

--- a/app/assets/javascripts/download-link.js
+++ b/app/assets/javascripts/download-link.js
@@ -17,7 +17,9 @@ function initializeDownloadLinks() {
     var path_parts = new URL(link.href).pathname.split('/');
     var filename = path_parts[path_parts.length - 1] || 'file';
 
-    fetch(link.href)
+    // cache: no-store is present because Chrome is not including
+    // the Origin header with the request without this set.
+    fetch(link.href, {cache: 'no-store'})
         .then(function(response) {
           return response.blob();
         })


### PR DESCRIPTION
This pull request implements a simple polyfill to get around a restriction of `a[download]` links, which is that they can't download files from a different origin. To get around this, we `fetch` the href, read it as a blob, generate a URL to the blob, and then use this as the link href with the download attribute set. Because the blob is treated as a same-origin resource, the download is allowed to proceed.

For users without JS, this will be a progressive enhancement, since the href will continue to open in a new tab within the browser (rather than being downloaded).


https://user-images.githubusercontent.com/292020/226475767-9bb953f5-c21b-457c-9f68-cb002e22a07b.mp4

