### PR TITLE
NZSL-167: Presign asset requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'pg', '~>1.2'
 # Use SQLite to access signs from a Signbank dictionary export
 gem 'sqlite3'
 
+gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'haml'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,22 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.3.3.0)
       execjs (~> 2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.878.0)
+    aws-sdk-core (3.190.2)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.76.0)
+      aws-sdk-core (~> 3, >= 3.188.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.142.0)
+      aws-sdk-core (~> 3, >= 3.189.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -175,6 +191,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    jmespath (1.6.2)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -420,6 +437,7 @@ PLATFORMS
 
 DEPENDENCIES
   autoprefixer-rails
+  aws-sdk-s3
   bootsnap (>= 1.1.0)
   brakeman
   bundle-audit

--- a/app/models/signbank/asset.rb
+++ b/app/models/signbank/asset.rb
@@ -11,7 +11,7 @@ module Signbank
     def url
       return unless super
 
-      AssetURL.new(super).url
+      AssetURL.new(super).url.to_s
     end
   end
 end

--- a/app/models/signbank/asset.rb
+++ b/app/models/signbank/asset.rb
@@ -9,7 +9,7 @@ module Signbank
     scope :image, -> { where("filename LIKE '%.png'") }
 
     def url
-      return unless super
+      return unless super.presence
 
       AssetURL.new(super).url.to_s
     end

--- a/app/models/signbank/asset.rb
+++ b/app/models/signbank/asset.rb
@@ -7,5 +7,11 @@ module Signbank
     default_scope -> { order(display_order: :asc) }
 
     scope :image, -> { where("filename LIKE '%.png'") }
+
+    def url
+      return unless super
+
+      AssetURL.new(super).url
+    end
   end
 end

--- a/app/models/signbank/asset_url.rb
+++ b/app/models/signbank/asset_url.rb
@@ -1,0 +1,69 @@
+module Signbank
+  class AssetURL
+    attr_reader :asset_url
+
+    class S3Adapter
+      cattr_accessor :region, :access_key_id, :secret_access_key, :endpoint
+      self.region = ENV.fetch('DICTIONARY_AWS_REGION', ENV.fetch('AWS_REGION', nil))
+      self.access_key_id = ENV.fetch('DICTIONARY_AWS_ACCESS_KEY_ID', nil)
+      self.secret_access_key = ENV.fetch('DICTIONARY_AWS_SECRET_ACCESS_KEY', nil)
+      self.endpoint = 's3.amazonaws.com'
+
+      def initialize(asset)
+        @asset = asset
+      end
+
+      def self.configured?
+        region && access_key_id && secret_access_key && client
+      end
+
+      def self.client
+        @client ||= Aws::S3::Client.new(region:, access_key_id:,
+                                        secret_access_key:)
+      rescue Aws::Errors::MissingCredentialsError, Aws::Errors::MissingRegionError
+        nil
+      end
+
+      def bucket_name
+        bucket_name, hostname = @asset.asset_url.host.split('.', 2)
+        raise ArgumentError, "Invalid hostname #{@asset.asset_url.host}" unless hostname == endpoint
+
+        bucket_name
+      end
+
+      def url(expires_in: 1.hour)
+        return unless self.class.configured?
+
+        object_key =  @asset.asset_url.path[1..]
+
+        URI.parse(
+          Aws::S3::Object.new(bucket_name, object_key, client: self.class.client)
+          .presigned_url(:get, expires_in: expires_in.to_i)
+        )
+      end
+    end
+
+    class PassthroughUrlAdapter
+      def initialize(asset)
+        @asset = asset
+      end
+
+      def self.configured?
+        true
+      end
+
+      def url(*)
+        return unless self.class.configured?
+
+        @asset.asset_url
+      end
+    end
+
+    delegate :url, to: :@adapter
+
+    def initialize(asset_url, adapter: nil)
+      @asset_url = URI.parse(asset_url)
+      @adapter = (adapter || [S3Adapter, PassthroughUrlAdapter].find(&:configured?)).new(self)
+    end
+  end
+end

--- a/app/models/signbank/example.rb
+++ b/app/models/signbank/example.rb
@@ -7,5 +7,11 @@ module Signbank
                       foreign_key: :word_id,
                       inverse_of: :examples
     default_scope -> { order(display_order: :asc).where.not(video: nil) }
+
+    def video
+      return unless super
+
+      AssetURL.new(super).url.to_s
+    end
   end
 end

--- a/app/models/signbank/example.rb
+++ b/app/models/signbank/example.rb
@@ -9,7 +9,7 @@ module Signbank
     default_scope -> { order(display_order: :asc).where.not(video: nil) }
 
     def video
-      return unless super
+      return unless super.presence
 
       AssetURL.new(super).url.to_s
     end

--- a/app/models/signbank/sign.rb
+++ b/app/models/signbank/sign.rb
@@ -43,6 +43,12 @@ module Signbank
       picture&.url
     end
 
+    def video
+      return unless super
+
+      AssetURL.new(super).url.to_s
+    end
+
     ##
     # These are all aliases for the object shape that
     # existing code is expecting

--- a/app/models/signbank/sign.rb
+++ b/app/models/signbank/sign.rb
@@ -44,7 +44,7 @@ module Signbank
     end
 
     def video
-      return unless super
+      return unless super.presence
 
       AssetURL.new(super).url.to_s
     end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections
@@ -11,7 +12,6 @@
 #   inflect.uncountable %w( fish sheep )
 # end
 
-# These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'URL'
+end

--- a/spec/models/signbank/asset_spec.rb
+++ b/spec/models/signbank/asset_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe Signbank::Asset, type: :model do
     end
   end
 
+  describe '#url' do
+    it 'is a Signbank::AssetURL' do
+      asset = Signbank::Asset.new(filename: 'test.png', url: '/test.png')
+      expect(asset.url).to be_a(URI)
+    end
+
+    it 'is nil when the URL is nil' do
+      asset = Signbank::Asset.new(filename: 'test.png', url: nil)
+      expect(asset.url).to be_nil
+    end
+  end
+
   describe '.scoped' do
     it 'is ordered by display_order' do
       sign = Signbank::Sign.create!(id: SecureRandom.uuid)

--- a/spec/models/signbank/asset_spec.rb
+++ b/spec/models/signbank/asset_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe Signbank::Asset, type: :model do
       asset = Signbank::Asset.new(url: nil)
       expect(asset.url).to be_nil
     end
+
+    it 'is nil when the URL is blank' do
+      asset = Signbank::Asset.new(url: "")
+      expect(asset.url).to be_nil
+    end
   end
 
   describe '.scoped' do

--- a/spec/models/signbank/asset_spec.rb
+++ b/spec/models/signbank/asset_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Signbank::Asset, type: :model do
     end
 
     it 'is nil when the URL is blank' do
-      asset = Signbank::Asset.new(url: "")
+      asset = Signbank::Asset.new(url: '')
       expect(asset.url).to be_nil
     end
   end

--- a/spec/models/signbank/asset_spec.rb
+++ b/spec/models/signbank/asset_spec.rb
@@ -18,13 +18,15 @@ RSpec.describe Signbank::Asset, type: :model do
   end
 
   describe '#url' do
-    it 'is a Signbank::AssetURL' do
-      asset = Signbank::Asset.new(filename: 'test.png', url: '/test.png')
-      expect(asset.url).to be_a(URI)
+    it 'uses Signbank::AssetURL' do
+      double = instance_double(Signbank::AssetURL, url: URI.parse('/test.png'))
+      allow(Signbank::AssetURL).to receive(:new).and_return(double)
+      asset = Signbank::Asset.new(url: 'test.png')
+      expect(asset.url).to eq '/test.png'
     end
 
     it 'is nil when the URL is nil' do
-      asset = Signbank::Asset.new(filename: 'test.png', url: nil)
+      asset = Signbank::Asset.new(url: nil)
       expect(asset.url).to be_nil
     end
   end

--- a/spec/models/signbank/asset_url_spec.rb
+++ b/spec/models/signbank/asset_url_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Signbank::AssetURL do
+  describe '#url' do
+    context 'when using S3Adapter' do
+      let(:asset_url) { 'https://example.s3.amazonaws.com/assets/asset.mp4' }
+      let(:adapter) { Signbank::AssetURL::S3Adapter }
+
+      it 'returns the presigned URL for the asset' do
+        asset = Signbank::AssetURL.new(asset_url, adapter:)
+        presigned_url = 'https://s3.amazonaws.com/bucket-name/asset.mp4?expires=1234567890'
+
+        allow(adapter).to receive(:configured?).and_return(true)
+        allow(adapter).to receive(:client).and_return(instance_double(Aws::S3::Client))
+        allow_any_instance_of(Aws::S3::Object).to receive(:presigned_url).and_return(presigned_url)
+
+        expect(asset.url).to eq(URI.parse(presigned_url))
+      end
+
+      it 'returns nil if S3Adapter is not configured' do
+        asset = Signbank::AssetURL.new(asset_url, adapter:)
+
+        allow(adapter).to receive(:configured?).and_return(false)
+
+        expect(asset.url).to be_nil
+      end
+
+      it 'raises an error if the URL does not have the expected hostname' do
+        asset_url = 'https://example.com/assets/asset.mp4'
+        asset = Signbank::AssetURL.new(asset_url, adapter:)
+        allow(adapter).to receive(:configured?).and_return(true)
+
+        expect { asset.url }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when using PassthroughUrlAdapter' do
+      let(:asset_url) { URI.parse('https://example.com/assets/asset.mp4') }
+      let(:adapter) { Signbank::AssetURL::PassthroughUrlAdapter }
+
+      it 'returns the original asset URL' do
+        asset = Signbank::AssetURL.new(asset_url.to_s, adapter:)
+
+        allow(adapter).to receive(:configured?).and_return(true)
+
+        expect(asset.url).to eq(asset_url)
+      end
+    end
+
+    context 'when no adapter is specified' do
+      let(:asset_url) { URI.parse('https://example.com/assets/asset.mp4') }
+
+      it 'uses the first configured adapter' do
+        asset = Signbank::AssetURL.new(asset_url.to_s)
+
+        allow(Signbank::AssetURL::S3Adapter).to receive(:configured?).and_return(false)
+        allow(Signbank::AssetURL::PassthroughUrlAdapter).to receive(:configured?).and_return(true)
+
+        expect(asset.url).to eq(asset_url)
+      end
+
+      it 'returns nil if no adapter is configured' do
+        asset = Signbank::AssetURL.new(asset_url.to_s)
+
+        allow(Signbank::AssetURL::S3Adapter).to receive(:configured?).and_return(false)
+        allow(Signbank::AssetURL::PassthroughUrlAdapter).to receive(:configured?).and_return(false)
+
+        expect(asset.url).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/signbank/example_spec.rb
+++ b/spec/models/signbank/example_spec.rb
@@ -18,4 +18,18 @@ RSpec.describe Signbank::Example, type: :model do
       expect(sign.examples).to be_empty
     end
   end
+
+  describe '#video' do
+    it 'uses Signbank::AssetURL' do
+      double = instance_double(Signbank::AssetURL, url: URI.parse('/test.png'))
+      allow(Signbank::AssetURL).to receive(:new).and_return(double)
+      example = Signbank::Example.new(video: 'test.png')
+      expect(example.video).to eq '/test.png'
+    end
+
+    it 'is nil when the URL is nil' do
+      example = Signbank::Example.new(video: nil)
+      expect(example.video).to be_nil
+    end
+  end
 end

--- a/spec/models/signbank/example_spec.rb
+++ b/spec/models/signbank/example_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Signbank::Example, type: :model do
     end
 
     it 'is nil when the URL is blank' do
-      example = Signbank::Example.new(video: "")
+      example = Signbank::Example.new(video: '')
       expect(example.video).to be_nil
     end
   end

--- a/spec/models/signbank/example_spec.rb
+++ b/spec/models/signbank/example_spec.rb
@@ -31,5 +31,10 @@ RSpec.describe Signbank::Example, type: :model do
       example = Signbank::Example.new(video: nil)
       expect(example.video).to be_nil
     end
+
+    it 'is nil when the URL is blank' do
+      example = Signbank::Example.new(video: "")
+      expect(example.video).to be_nil
+    end
   end
 end

--- a/spec/models/signbank/sign_spec.rb
+++ b/spec/models/signbank/sign_spec.rb
@@ -114,5 +114,10 @@ module Signbank
       sign = Signbank::Sign.new(video: nil)
       expect(sign.video).to be_nil
     end
+
+    it 'is nil when the URL is blank' do
+      sign = Signbank::Sign.new(video: "")
+      expect(sign.video).to be_nil
+    end
   end
 end

--- a/spec/models/signbank/sign_spec.rb
+++ b/spec/models/signbank/sign_spec.rb
@@ -116,7 +116,7 @@ module Signbank
     end
 
     it 'is nil when the URL is blank' do
-      sign = Signbank::Sign.new(video: "")
+      sign = Signbank::Sign.new(video: '')
       expect(sign.video).to be_nil
     end
   end

--- a/spec/models/signbank/sign_spec.rb
+++ b/spec/models/signbank/sign_spec.rb
@@ -101,4 +101,18 @@ module Signbank
       end
     end
   end
+
+  describe '#url' do
+    it 'uses Signbank::AssetURL' do
+      double = instance_double(Signbank::AssetURL, url: URI.parse('/test.png'))
+      allow(Signbank::AssetURL).to receive(:new).and_return(double)
+      sign = Signbank::Sign.new(video: 'test.png')
+      expect(sign.video).to eq '/test.png'
+    end
+
+    it 'is nil when the URL is nil' do
+      sign = Signbank::Sign.new(video: nil)
+      expect(sign.video).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This pull request ports over the asset presigning class [from NZSL Share](https://github.com/ackama/nzsl-share/pull/603), and uses this when rendering:

* Sign examples
* Sign illustrations
* Sign video

If a dictionary access key pair is present, it will pre-sign AWS URLs for assets. If no key pair is present, it will passthrough the URLs unaltered. 

Here is an example of a sign illustration when a key pair is configured:

![image](https://github.com/ODNZSL/nzsl-online/assets/292020/53e07ca6-644a-4655-b1f8-d1c33e65ff4b)

And without the key pair (note that lack of signature, etc):

![image](https://github.com/ODNZSL/nzsl-online/assets/292020/2dc0a68c-d11f-4a6d-be44-924ccd65c3c6)
