### PR TITLE
NZSL-164: Show the database version in the footer

### DIFF
--- a/app/models/signbank/record.rb
+++ b/app/models/signbank/record.rb
@@ -6,6 +6,10 @@ module Signbank
     # to create test records
     after_initialize { readonly! unless Rails.env.test? }
 
+    def self.database_version
+      connection.execute('PRAGMA user_version').first['user_version']
+    end
+
     ##
     # Useful for testing - related Signbank records don't have primary keys,
     # so in this case we consider them equal if they are the same type and

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -46,17 +46,21 @@
   </div>
   <div class="copyright">
     <div class="small-10 small-centered medium-8 large-6">
-      <% if @footer && @footer.first_part %>
-        <%= link_to((image_tag "https://i.creativecommons.org/l/by-nc-sa/3.0/88x31.png"), "https://creativecommons.org/licenses/by-nc-sa/3.0", target:"_blank" ) %>
-        <div class="footer-link">
-          NZSL Dictionary by
-          <%= link_to "Deaf Studies Research Unit, Victoria University of Wellington", "https://www.victoria.ac.nz/lals/research/projects/dsru.aspx", target: "_blank" %>
-          is licensed under a
-          <%= link_to "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.","https://creativecommons.org/licenses/by-nc-sa/4.0/", target: "_blank" %>
-          <br/>
-          <%= link_to 'View in NZSL', @footer.path %>
-        </div>
-      <% end %>
+      <%= link_to((image_tag "https://i.creativecommons.org/l/by-nc-sa/3.0/88x31.png"), "https://creativecommons.org/licenses/by-nc-sa/3.0", target:"_blank" ) %>
+      <div class="footer-link">
+        NZSL Dictionary by
+        <%= link_to "Deaf Studies Research Unit, Victoria University of Wellington", "https://www.victoria.ac.nz/lals/research/projects/dsru.aspx", target: "_blank" %>
+        is licensed under a
+        <%= link_to "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.","https://creativecommons.org/licenses/by-nc-sa/4.0/", target: "_blank" %>
+
+          <% if (version = Signbank::Record.database_version) %>
+          <br />
+          Database version <%= version %>.
+        <% end %>
+
+        <br/>
+        <%= link_to 'View in NZSL', @footer.path if @footer && @footer.first_part %>
+      </div>
     </div>
   </div>
 </footer>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -46,7 +46,10 @@
   </div>
   <div class="copyright">
     <div class="small-10 small-centered medium-8 large-6">
-      <%= link_to((image_tag "https://i.creativecommons.org/l/by-nc-sa/3.0/88x31.png"), "https://creativecommons.org/licenses/by-nc-sa/3.0", target:"_blank" ) %>
+      <%= link_to "https://creativecommons.org/licenses/by-nc-sa/3.0", target:"_blank" do %>
+        <%= image_tag "https://i.creativecommons.org/l/by-nc-sa/3.0/88x31.png", alt: "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License badge" %>
+      <% end %>
+
       <div class="footer-link">
         NZSL Dictionary by
         <%= link_to "Deaf Studies Research Unit, Victoria University of Wellington", "https://www.victoria.ac.nz/lals/research/projects/dsru.aspx", target: "_blank" %>

--- a/spec/models/signbank/record_spec.rb
+++ b/spec/models/signbank/record_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Signbank::Record do
+  describe '.database_version' do
+    it 'returns the user version of the database' do
+      version = 42
+      allow(Signbank::Record.connection).to receive(:execute)
+        .with('PRAGMA user_version')
+        .and_return([{ 'user_version' => version }])
+
+      expect(Signbank::Record.database_version).to eq(version)
+    end
+  end
+end

--- a/spec/views/shared/_footer.html.erb_spec.rb
+++ b/spec/views/shared/_footer.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'shared/_footer.html.erb' do
+  it 'renders the database version when available' do
+    allow(Signbank::Record).to receive(:database_version).and_return(123_456)
+    render partial: 'shared/footer', locals: { last: false }
+    expect(rendered).to include 'Database version 123456'
+  end
+
+  it 'does not render the database version if it is unavailable' do
+    allow(Signbank::Record).to receive(:database_version).and_return(nil)
+    render partial: 'shared/footer', locals: { last: false }
+    expect(rendered).not_to include 'Database version 123456'
+  end
+end


### PR DESCRIPTION
This pull request adds the database version to the website footer as implemented by https://github.com/ackama/nzsl-share/pull/604. 

I've moved the footer template ivars around a little, since the purpose of the `@footer` page is to provide a NZSL translation of the copyright info, which I think we should always show regardless of whether there is a translation available or not.

![image](https://github.com/ODNZSL/nzsl-online/assets/292020/48498882-0df9-4b86-bef0-c05e8c25eba4)
