### PR TITLE
Add some conditionals to handle prerelease signs missing videos

### DIFF
--- a/app/views/signs/_sign_of_the_day.html.haml
+++ b/app/views/signs/_sign_of_the_day.html.haml
@@ -1,4 +1,4 @@
-- if sign.present?
+- if sign.present? && sign.video
   .sign-of-the-day.text-center
     .column-block
       %h3= t('signs.sign_of_the_day')

--- a/app/views/signs/search.html.haml
+++ b/app/views/signs/search.html.haml
@@ -7,9 +7,10 @@
   - @signs.each do |sign|
     .search-results__card
       - @query[:s] ? query_text = @query[:s].join(" ") : query_text = " "
-      .video-container.video--placeholder
-        %i.fi-play.play-button
-        = videojs_rails sources: { mp4: sign.video }, class: "normal", controlsList:"nodownload", controls: false, preload: "metadata", loop: true
+      - if sign.video
+        .video-container.video--placeholder
+          %i.fi-play.play-button
+          = videojs_rails sources: { mp4: sign.video }, class: "normal", controlsList:"nodownload", controls: false, preload: "metadata", loop: true
       -# %span.search-results--placeholder
       .clickable_link.small-12.small-centered
         %a.div_link{:href => "#{sign_url(sign.id)}"}

--- a/app/views/signs/show.html.haml
+++ b/app/views/signs/show.html.haml
@@ -28,11 +28,12 @@
             %i.fi-plus
           %span.buttons-action.add-button-text Add to Vocab Sheet
     .videos.small-12.medium-5
-      .video-container
-        %i.fi-play.play-button
-        = videojs_rails sources: { mp4: @sign.video }, class: "main_video video", controlsList:"nodownload", controls: true, preload: "metadata", loop: true
-        = play_video_button('signs.show.in_slow_motion', nil, class: 'float-left slow')
-        = play_video_button('signs.show.at_normal_speed', nil, class: 'float-left normal')
+      - if @sign.video
+        .video-container
+          %i.fi-play.play-button
+          = videojs_rails sources: { mp4: @sign.video }, class: "main_video video", controlsList:"nodownload", controls: true, preload: "metadata", loop: true
+          = play_video_button('signs.show.in_slow_motion', nil, class: 'float-left slow')
+          = play_video_button('signs.show.at_normal_speed', nil, class: 'float-left normal')
       .glosses-container.glosses.small-12.float-left
         %h2.main_gloss= @sign.gloss_main
         %h2.secondary_gloss= @sign.gloss_secondary
@@ -44,6 +45,7 @@
       .examples-container.clearfix.videos.small-12.small-centered.medium-5.medium-uncentered
         %h3= t('signs.show.usage_examples')
         - @sign.examples.each do |example|
+          - next unless example.video
           .typography.videos
             .video-container
               %i.fi-play.play-button


### PR DESCRIPTION
This pull request adds conditional checks to handle missing videos. Within a published dataset, all signs should have videos (this is an editorial check). We're adding support for prerelease database exports though, in which case data that we previously expected to be present (such as videos) can now be missing.

