### PR TITLE
CCSD-5856: update app and production config to switch to mailgun

### DIFF
--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -4,6 +4,6 @@ class FeedbackMailer < ApplicationMailer
   def email(model)
     @feedback = model
     attachments[@feedback.video_file_name] = File.read(@feedback.video.path) if @feedback.video_file_name
-    mail(subject: 'NZSL Website Feedback')
+    mail(to: CONTACT_EMAIL, subject: 'NZSL Website Feedback')
   end
 end

--- a/config/app.yml
+++ b/config/app.yml
@@ -24,3 +24,6 @@ staging:
 
 production:
   <<: *default
+  smtp_hostname: <%= ENV['SMTP_HOSTNAME'] %>
+  smtp_user_name: <%= ENV['SMTP_USER_NAME'] %>
+  smtp_password: <%= ENV['SMTP_PASSWORD'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,17 +105,17 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options[:protocol] = "https"
+  config.action_mailer.default_url_options[:protocol] = 'https'
   config.action_mailer.smtp_settings = {
     address: Rails.application.config.app.smtp_hostname,
     port: 587,
     enable_starttls_auto: true,
     user_name: Rails.application.config.app.smtp_user_name,
     password: Rails.application.config.app.smtp_password,
-    authentication: "login",
-    domain: ENV.fetch("HOSTNAME", nil)
+    authentication: 'login',
+    domain: ENV.fetch('HOSTNAME', nil)
   }
-  config.action_mailer.asset_host = "https://#{ENV.fetch("HOSTNAME", nil)}"
+  config.action_mailer.asset_host = "https://#{ENV.fetch('HOSTNAME', nil)}"
 
   config.action_mailer.default_url_options = { host: ENV['MAILER_URL'] }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,18 +103,19 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-
-  ActionMailer::Base.smtp_settings = {
-    address: 'smtp.sendgrid.net',
-    port: '587',
-    authentication: :plain,
-    user_name: ENV['SENDGRID_USERNAME'],
-    password: ENV['SENDGRID_PASSWORD'],
-    domain: 'heroku.com',
-    enable_starttls_auto: true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options[:protocol] = "https"
+  config.action_mailer.smtp_settings = {
+    address: Rails.application.config.app.smtp_hostname,
+    port: 587,
+    enable_starttls_auto: true,
+    user_name: Rails.application.config.app.smtp_user_name,
+    password: Rails.application.config.app.smtp_password,
+    authentication: "login",
+    domain: ENV.fetch("HOSTNAME", nil)
   }
-
-  ActionMailer::Base.delivery_method = :smtp
+  config.action_mailer.asset_host = "https://#{ENV.fetch("HOSTNAME", nil)}"
 
   config.action_mailer.default_url_options = { host: ENV['MAILER_URL'] }
 

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 ADMIN_EMAIL = ENV.fetch('ADMIN_EMAIL', 'micky.vale@vuw.ac.nz')
+CONTACT_EMAIL = ENV.fetch('CONTACT_EMAIL', ADMIN_EMAIL)


### PR DESCRIPTION
Emails are not currently sending from the feedback form. NZSL Share and Signbank are using Mailgun, so it makes sense to switch NZSL Dictionary to use mailgun as well rather than sendgrid. 

This PR makes the changes to the app and production config to use mailgun for email sending. It also adds an env var for `CONTACT_EMAIL` so we can update the contact email if needed. 