### PR TITLE
fix: don't have `default_url_options` twice in the config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,7 +105,6 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options[:protocol] = 'https'
   config.action_mailer.smtp_settings = {
     address: Rails.application.config.app.smtp_hostname,
     port: 587,
@@ -117,7 +116,7 @@ Rails.application.configure do
   }
   config.action_mailer.asset_host = "https://#{ENV.fetch('HOSTNAME', nil)}"
 
-  config.action_mailer.default_url_options = { host: ENV['MAILER_URL'] }
+  config.action_mailer.default_url_options = { host: ENV['MAILER_URL'], protocol: 'https' }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
The most recent deployment failed 


```
rake aborted!
       NoMethodError: undefined method '[]=' for nil (NoMethodError)
         config.action_mailer.default_url_options[:protocol] = 'https'
```

I realised that I was specifying the `default_url_options` twice in the config, and the second place was the correct one, so I added the protocol there. 