### PR TITLE
fix: change mailer setup to have default `mail_from`

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'website@nzsl.vuw.ac.nz'
+  default from: Rails.application.config.app.mail_from
   default to: ADMIN_EMAIL
   layout 'mailer'
 end

--- a/config/app.yml
+++ b/config/app.yml
@@ -24,6 +24,7 @@ staging:
 
 production:
   <<: *default
+  mail_from: <%= ENV['MAIL_FROM'] %>
   smtp_hostname: <%= ENV['SMTP_HOSTNAME'] %>
   smtp_user_name: <%= ENV['SMTP_USER_NAME'] %>
   smtp_password: <%= ENV['SMTP_PASSWORD'] %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -15,7 +15,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = Rails.application.config.app.mail_from
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Update `mail_from` and make it an env var so we can update it in heroku if needed.

This also updates the devise mail sender to make sure password reset emails are sent from the same default `mail_from` email address. 