### PR TITLE
fix: set reply to on feedback mailer

### DIFF
--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -4,6 +4,6 @@ class FeedbackMailer < ApplicationMailer
   def email(model)
     @feedback = model
     attachments[@feedback.video_file_name] = File.read(@feedback.video.path) if @feedback.video_file_name
-    mail(to: CONTACT_EMAIL, subject: 'NZSL Website Feedback')
+    mail(to: CONTACT_EMAIL, subject: 'NZSL Website Feedback', reply_to: @feedback.email)
   end
 end


### PR DESCRIPTION
In addition to the changes to the mailer [here](https://github.com/ODNZSL/nzsl-online/pull/1670), this sets the reply to on the feedback email so replies to the feedback email go to the person who submitted the feedback form. 