### PR TITLE
feat: supporting using `turnstile` to reduce spam in feedback form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem 'will_paginate'
 gem 'faraday'
 gem 'faraday_middleware'
 
+gem 'rails_cloudflare_turnstile'
+
 # logins
 gem 'devise'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,6 +355,9 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_cloudflare_turnstile (0.5.0)
+      faraday (>= 1.0, < 3.0)
+      rails (>= 6.0, < 8.2)
     railties (8.1.2.1)
       actionpack (= 8.1.2.1)
       activesupport (= 8.1.2.1)
@@ -548,6 +551,7 @@ DEPENDENCIES
   rack-canonical-host (~> 1.0.0)
   rails (~> 8.1.1)
   rails-controller-testing
+  rails_cloudflare_turnstile
   raygun4ruby
   rb-readline
   rerun

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   layout :layout_by_resource
 
+  helper_method :turnstile_enabled?
+
   before_action :staging_http_auth
 
   private
@@ -68,5 +70,9 @@ class ApplicationController < ActionController::Base
     authenticate_or_request_with_http_basic('Username and Password please') do |username, password|
       username == ENV['HTTP_BASIC_AUTH_USERNAME'] && password == ENV['HTTP_BASIC_AUTH_PASSWORD']
     end
+  end
+
+  def turnstile_enabled?
+    Rails.env.production?
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -8,7 +8,11 @@ class FeedbackController < ApplicationController
   end
 
   def create
-    process_feedback
+    if turnstile_enabled? && !valid_turnstile?(params)
+      flash.now[:feedback_error] = t('feedback.failure')
+    else
+      process_feedback
+    end
 
     @feedback = Feedback.new
     @page = Page.find(params[:page_id].to_i)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,6 +18,8 @@
     = stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true
     = javascript_include_tag "application", "defer" => "defer", "data-turbolinks-track" => false
     = yield :head
+    - if turnstile_enabled?
+      = cloudflare_turnstile_script_tag
     - if params[:print]
       = stylesheet_link_tag('print', media: 'all')
       = stylesheet_link_tag('print_screen', media: 'screen')

--- a/app/views/pages/feedback.html.haml
+++ b/app/views/pages/feedback.html.haml
@@ -76,4 +76,6 @@
           = f.label :message, "Message:"
           = f.text_area :message, rows: "10", class: "message-input"
       %input{ type: "hidden", value: @page.id, name: "page_id" }
-        = f.submit t("feedback.submit"), class: "send-feedback-button button"
+      - if turnstile_enabled?
+        = cloudflare_turnstile
+      = f.submit t("feedback.submit"), class: "send-feedback-button button"

--- a/config/initializers/cloudflare_turnstile.rb
+++ b/config/initializers/cloudflare_turnstile.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+CloudflareTurnstile.configure do |config|
+  config.site_key = ENV["TURNSTILE_SITE_KEY"]
+  config.secret_key = ENV["TURNSTILE_SECRET_KEY"]
+end

--- a/config/initializers/cloudflare_turnstile.rb
+++ b/config/initializers/cloudflare_turnstile.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 CloudflareTurnstile.configure do |config|
-  config.site_key = ENV["TURNSTILE_SITE_KEY"]
-  config.secret_key = ENV["TURNSTILE_SECRET_KEY"]
+  config.site_key = ENV['TURNSTILE_SITE_KEY']
+  config.secret_key = ENV['TURNSTILE_SECRET_KEY']
 end

--- a/config/initializers/cloudflare_turnstile.rb
+++ b/config/initializers/cloudflare_turnstile.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 RailsCloudflareTurnstile.configure do |config|
-  config.site_key = ENV.fetch('TURNSTILE_SITE_KEY', '1x00000000000000000000AA')
-  config.secret_key = ENV.fetch('TURNSTILE_SECRET_KEY', '1x0000000000000000000000000000000AA')
+  # fallback values are cloudflare test keys: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+  config.site_key = ENV.fetch('TURNSTILE_SITE_KEY', '2x00000000000000000000AB')
+  config.secret_key = ENV.fetch('TURNSTILE_SECRET_KEY', '2x0000000000000000000000000000000AA')
 end

--- a/config/initializers/cloudflare_turnstile.rb
+++ b/config/initializers/cloudflare_turnstile.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 RailsCloudflareTurnstile.configure do |config|
-  config.site_key = ENV["TURNSTILE_SITE_KEY"]
-  config.secret_key = ENV["TURNSTILE_SECRET_KEY"]
+  config.site_key = ENV['TURNSTILE_SITE_KEY']
+  config.secret_key = ENV['TURNSTILE_SECRET_KEY']
 end

--- a/config/initializers/cloudflare_turnstile.rb
+++ b/config/initializers/cloudflare_turnstile.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 RailsCloudflareTurnstile.configure do |config|
-  config.site_key = ENV['TURNSTILE_SITE_KEY']
-  config.secret_key = ENV['TURNSTILE_SECRET_KEY']
+  config.site_key = ENV.fetch('TURNSTILE_SITE_KEY', '1x00000000000000000000AA')
+  config.secret_key = ENV.fetch('TURNSTILE_SECRET_KEY', '1x0000000000000000000000000000000AA')
 end

--- a/config/initializers/cloudflare_turnstile.rb
+++ b/config/initializers/cloudflare_turnstile.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-CloudflareTurnstile.configure do |config|
-  config.site_key = ENV['TURNSTILE_SITE_KEY']
-  config.secret_key = ENV['TURNSTILE_SECRET_KEY']
+RailsCloudflareTurnstile.configure do |config|
+  config.site_key = ENV["TURNSTILE_SITE_KEY"]
+  config.secret_key = ENV["TURNSTILE_SECRET_KEY"]
 end

--- a/env-example
+++ b/env-example
@@ -5,7 +5,3 @@ APP_PROTOCOL: "http"
 
 # The latest public release
 DICTIONARY_DATABASE_S3_LOCATION="s3://nzsl-signbank-media-production/dictionary-exports/nzsl.db"
-
-# Keys for using cloudflare turnstile on forms:
-TURNSTILE_SITE_KEY:
-TURNSTILE_SECRET_KEY:

--- a/env-example
+++ b/env-example
@@ -5,3 +5,7 @@ APP_PROTOCOL: "http"
 
 # The latest public release
 DICTIONARY_DATABASE_S3_LOCATION="s3://nzsl-signbank-media-production/dictionary-exports/nzsl.db"
+
+# Keys for using cloudflare turnstile on forms:
+TURNSTILE_SITE_KEY:
+TURNSTILE_SECRET_KEY:


### PR DESCRIPTION
This PR adds in turnstile as a captcha equivalent to reduce the amount of spam being sent through feedback forms. 

The fallback keys are the official cloudflare test keys, as `rspec` kept failing in ci when there were no keys present (this wasn't happening locally). 