### PR TITLE
fix: form returning 500 errors with turnstile enabled

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FeedbackController < ApplicationController
+  include RailsCloudflareTurnstile::ControllerHelpers
+
   before_action :find_vocab_sheet, :set_search_query, :footer_content
 
   def new
@@ -8,7 +10,7 @@ class FeedbackController < ApplicationController
   end
 
   def create
-    if turnstile_enabled? && !valid_turnstile?(params)
+    if !cloudflare_turnstile_ok?
       flash.now[:feedback_error] = t('feedback.failure')
     else
       process_feedback

--- a/app/views/pages/feedback.html.haml
+++ b/app/views/pages/feedback.html.haml
@@ -76,6 +76,5 @@
           = f.label :message, "Message:"
           = f.text_area :message, rows: "10", class: "message-input"
       %input{ type: "hidden", value: @page.id, name: "page_id" }
-      - if turnstile_enabled?
-        = cloudflare_turnstile
+      = cloudflare_turnstile
       = f.submit t("feedback.submit"), class: "send-feedback-button button"

--- a/config/initializers/cloudflare_turnstile.rb
+++ b/config/initializers/cloudflare_turnstile.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RailsCloudflareTurnstile.configure do |config|
-  config.site_key = ENV.fetch("TURNSTILE_SITE_KEY", "1x00000000000000000000AA")
-  config.secret_key = ENV.fetch("TURNSTILE_SECRET_KEY", "1x0000000000000000000000000000000AA")
+  # fallback values are cloudflare test keys: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+  config.site_key = ENV.fetch('TURNSTILE_SITE_KEY', '2x00000000000000000000AB')
+  config.secret_key = ENV.fetch('TURNSTILE_SECRET_KEY', '2x0000000000000000000000000000000AA')
   config.enabled = Rails.env.production?
 end

--- a/config/initializers/cloudflare_turnstile.rb
+++ b/config/initializers/cloudflare_turnstile.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RailsCloudflareTurnstile.configure do |config|
-  # fallback values are cloudflare test keys: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
-  config.site_key = ENV.fetch('TURNSTILE_SITE_KEY', '2x00000000000000000000AB')
-  config.secret_key = ENV.fetch('TURNSTILE_SECRET_KEY', '2x0000000000000000000000000000000AA')
+  config.site_key = ENV.fetch("TURNSTILE_SITE_KEY", "1x00000000000000000000AA")
+  config.secret_key = ENV.fetch("TURNSTILE_SECRET_KEY", "1x0000000000000000000000000000000AA")
+  config.enabled = Rails.env.production?
 end


### PR DESCRIPTION
Initially I tried to implement turnstile without using a gem to help, and when I switched to using a gem,  I missed updating the controller to use the helpers from the library, resulting in 500 errors when you try to submit feedback via the form. 

This change uses the helpers from the gem I used to help implement turnstile for the form: https://github.com/instrumentl/rails-cloudflare-turnstile/blob/main/lib/rails_cloudflare_turnstile/controller_helpers.rb

I updated to using the "always pass" keys from cloudflare to test that this works locally 

<img width="2092" height="450" alt="CleanShot 2026-07-07 at 08 26 09@2x" src="https://github.com/user-attachments/assets/a8b78f07-27b8-4cdf-a991-725fbf102e80" />


