### PR TITLE
CCSD-5856: update feedback button styling and form order

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -411,7 +411,13 @@ abbr {
 
 .avoid-bottom-margin { margin-bottom: 0; }
 
-.send-feedback-button { margin-top: 20px; }
+.send-feedback-button {
+  margin-top: 20px;
+  height: 2.5rem;
+  width: 10rem;
+  font-size: medium;
+  padding: 10px;
+}
 
 .inline-errors {
   color: #f53;

--- a/app/views/pages/feedback.html.haml
+++ b/app/views/pages/feedback.html.haml
@@ -76,5 +76,6 @@
           = f.label :message, "Message:"
           = f.text_area :message, rows: "10", class: "message-input"
       %input{ type: "hidden", value: @page.id, name: "page_id" }
-      = cloudflare_turnstile
       = f.submit t("feedback.submit"), class: "send-feedback-button button"
+      %br/
+      = cloudflare_turnstile


### PR DESCRIPTION
Increase the size of the send feedback button and font, and reorder the form so the captcha check sits at the end 

<img width="2842" height="1102" alt="CleanShot 2026-07-09 at 13 01 21@2x" src="https://github.com/user-attachments/assets/655655f8-43c1-4572-8081-5b99df56014b" />
