### PR TITLE
fix: add underline on hover to make it clear there's a link

### DIFF
--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -7,6 +7,12 @@
   }
 }
 
+.footer-copyright-link {
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 footer {
   color: $light-grey;
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -49,8 +49,8 @@
       <div class="footer-link">
         NZSL Dictionary by
         <%= link_to "Deaf Studies Research Unit, Victoria University of Wellington", "https://www.victoria.ac.nz/lals/research/projects/dsru.aspx", target: "_blank" %>
-        &copy; Victoria University of Wellington 2011- <%= Time.current.year =%> Use of content subject to our
-        <%= link_to "terms", "/copyright", target: "_blank" %>
+        &copy; Victoria University of Wellington 2011- <%= Time.current.year =%> Use of content
+        <%= link_to "subject to our terms", "/copyright", target: "_blank", class: "footer-copyright-link" %>
 
           <% if (version = Signbank::Record.database_version) %>
           <br />


### PR DESCRIPTION
Adds underline on hover to the link in footer, to make it clear it's a link