### PR TITLE
fix: move entire sentence into link tag

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -49,8 +49,8 @@
       <div class="footer-link">
         NZSL Dictionary by
         <%= link_to "Deaf Studies Research Unit, Victoria University of Wellington", "https://www.victoria.ac.nz/lals/research/projects/dsru.aspx", target: "_blank" %>
-        &copy; Victoria University of Wellington 2011- <%= Time.current.year =%> Use of content
-        <%= link_to "subject to our terms", "/copyright", target: "_blank", class: "footer-copyright-link" %>
+        &copy; Victoria University of Wellington 2011- <%= Time.current.year =%>
+        <%= link_to "Use of content subject to our terms", "/copyright", target: "_blank", class: "footer-copyright-link" %>
 
           <% if (version = Signbank::Record.database_version) %>
           <br />


### PR DESCRIPTION
Requested to move the entire sentence "Use of content subject to our terms" into the link