### PR TITLE
chore: sort rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,5 @@
 # Built-in config:
 # https://github.com/bbatsov/rubocop/blob/master/config/default.yml
-
 require:
   - rubocop-rails
   - rubocop-performance
@@ -11,53 +10,103 @@ AllCops:
     - 'node_modules/**/*'
     - 'db/schema.rb'
 
-Rails/WhereNot:
+Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true
 
-Performance/Sum:
+Layout/LineLength:
+  Max: 130
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/DuplicateElsifCondition:
   Enabled: true
 
 Lint/DuplicateRequire:
   Enabled: true
 
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
 Lint/EmptyFile:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
   Enabled: true
 
 Lint/TrailingCommaInAttributeDeclaration:
   Enabled: true
 
+Lint/UnreachableLoop:
+  Enabled: true
+
 Lint/UselessMethodDefinition:
   Enabled: true
 
-Style/CombinableLoops:
-  Enabled: true
+Lint/Void:
+  Enabled: false # see spec/controllers/vocab_sheet_controller_spec.rb
 
-Style/KeywordParametersOrder:
-  Enabled: true
+Metrics/AbcSize:
+  Max: 26
 
-Style/RedundantSelfAssignment:
-  Enabled: true
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+    - 'config/**/*.rb'
 
-Style/SoleNestedConditional:
-  Enabled: true
+Metrics/ClassLength:
+  Max: 150
 
-Rails/AfterCommitOverride:
-  Enabled: true
+Metrics/CyclomaticComplexity:
+  Max: 12
 
-Rails/SquishedSQLHeredocs:
-  Enabled: true
+Metrics/MethodLength:
+  Max: 20
 
-Style/AccessorGrouping:
-  Enabled: true
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
 
-Style/BisectedAttrAccessor:
-  Enabled: true
+Metrics/PerceivedComplexity:
+  Max: 12
 
-Style/RedundantAssignment:
-  Enabled: true
+Naming/FileName:
+  Exclude:
+    - Gemfile
+    - Gemfile.lock
 
-Style/RedundantFetchBlock:
-  Enabled: true
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
 
 Performance/AncestorsInclude:
   Enabled: true
@@ -83,91 +132,20 @@ Performance/Squeeze:
 Performance/StringInclude:
   Enabled: true
 
-Lint/Void:
-  Enabled: false # see spec/controllers/vocab_sheet_controller_spec.rb
-
-Layout/SpaceAroundMethodCallOperator:
+Performance/Sum:
   Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
-
-Style/ExponentialNotation:
-  Enabled: true
-
-Style/HashEachMethods:
-  Enabled: true
-
-Naming/VariableNumber:
-  EnforcedStyle: snake_case
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Style/Documentation:
-  Enabled: false
-
-Layout/LineLength:
-  Max: 130
-
-Metrics/ClassLength:
-  Max: 150
-
-Metrics/MethodLength:
-  Max: 20
-
-Metrics/AbcSize:
-  Max: 26
-
-Metrics/PerceivedComplexity:
-  Max: 12
-
-Rails/FilePath:
-  EnforcedStyle: arguments
-
-Metrics/CyclomaticComplexity:
-  Max: 12
-
-Metrics/ModuleLength:
-  Exclude:
-    - 'spec/**/*_spec.rb'
 
 Performance/UnfreezeString:
   Enabled: false
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*_spec.rb'
-    - 'config/**/*.rb'
-
-Style/PercentLiteralDelimiters:
-  Enabled: false
-
-Naming/FileName:
-  Exclude:
-    - Gemfile
-    - Gemfile.lock
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: true
-
 Rails/ActiveRecordCallbacksOrder:
   Enabled: true
+
+Rails/AfterCommitOverride:
+  Enabled: true
+
+Rails/FilePath:
+  EnforcedStyle: arguments
 
 Rails/FindById:
   Enabled: true
@@ -199,50 +177,41 @@ Rails/RenderPlainText:
 Rails/ShortI18n:
   Enabled: true
 
+Rails/SquishedSQLHeredocs:
+  Enabled: true
+
 Rails/WhereExists:
   Enabled: true
 
-Lint/BinaryOperatorWithIdenticalOperands:
+Rails/WhereNot:
   Enabled: true
 
-Lint/DuplicateElsifCondition:
-  Enabled: true
-
-Lint/DuplicateRescueException:
-  Enabled: true
-
-Lint/EmptyConditionalBody:
-  Enabled: true
-
-Lint/FloatComparison:
-  Enabled: true
-
-Lint/MissingSuper:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/OutOfRangeRegexpRef:
-  Enabled: true
-
-Lint/SelfAssignment:
-  Enabled: true
-
-Lint/TopLevelReturnWithArgument:
-  Enabled: true
-
-Lint/UnreachableLoop:
+Style/AccessorGrouping:
   Enabled: true
 
 Style/ArrayCoercion:
   Enabled: true
 
+Style/BisectedAttrAccessor:
+  Enabled: true
+
 Style/CaseLikeIf:
   Enabled: true
 
+Style/CombinableLoops:
+  Enabled: true
+
+Style/Documentation:
+  Enabled: false
+
 Style/ExplicitBlockArgument:
   Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
 
 Style/GlobalStdStream:
   Enabled: true
@@ -250,11 +219,32 @@ Style/GlobalStdStream:
 Style/HashAsLastArrayItem:
   Enabled: true
 
+Style/HashEachMethods:
+  Enabled: true
+
 Style/HashLikeCase:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/KeywordParametersOrder:
   Enabled: true
 
 Style/OptionalBooleanParameter:
   Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/RedundantAssignment:
+  Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: true
 
 Style/RedundantFileExtensionInRequire:
   Enabled: true
@@ -265,7 +255,16 @@ Style/RedundantRegexpCharacterClass:
 Style/RedundantRegexpEscape:
   Enabled: true
 
+Style/RedundantSelfAssignment:
+  Enabled: true
+
 Style/SingleArgumentDig:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true
+
+Style/SoleNestedConditional:
   Enabled: true
 
 Style/StringConcatenation:


### PR DESCRIPTION
I think this makes it easier to review what configuration we're actually using - the sorting priority is:

1. document start marker
2. `plugins`
3. base config properties such as `inherit_gem`
4. everything else, alphabetically but ignoring `:` and newline characters so that plugin configs are put before their cops

<details>
<summary>This is the script I have used to do the sorting</summary>

```ruby
class SortRubocopConfig
  # @param [String] config_file_path
  def self.run(config_file_path)
    new(config_file_path).sort!
  end

  # @param [String] config_file_path
  def initialize(config_file_path)
    # @type [String]
    @config_file_path = config_file_path

    # @type [Hash]
    @sections = {}

    parse_sections
  end

  def sort!
    sorted_sections = @sections.sort_by do |k, _|
      [
        # document start marker
        k == "---\n" ? -1 : 0,
        # plugins list
        k == "plugins:\n" ? -1 : 0,
        # base config properties (i.e "inherit_gem")
        k[0].downcase == k[0] ? -1 : 0,
        # namespaces
        # k.include?("/") ? 1 : 0,
        # everything else without colons or newlines so that plugin config will be
        # put before cop config, since colons are alphabetically smaller than slashes
        k.sub(/:\s*\z/, "")
      ]
    end

    joined = sorted_sections.map { |_, lines| lines.join }.join("\n")

    # make sure there isn't a blank line after the start marker to keep prettier happy
    File.write(@config_file_path, joined.gsub("---\n\n", "---\n"))
  end

  private

  def parse_sections
    section_name = ""
    section_lines = []

    File.readlines(@config_file_path).each do |line|
      # skip empty lines entirely
      next if line.strip.empty?

      # if the line does not start with a space, the previous section (if there
      # is one) must have finished since YAML is indentation based
      unless line.start_with?(" ")
        unless section_name.empty?
          add_section(section_name, section_lines)

          section_name = ""
          section_lines = []
        end

        # if the line is not a comment, it must be the start of the section
        unless line.start_with?("#")
          section_name = line

          puts "found section #{section_name}"
        end
      end

      section_lines << line
    end

    # add the last section we were parsing
    add_section(section_name, section_lines) unless section_name.empty?
  end

  # @param [String] name
  # @param [Array<String>] lines
  def add_section(name, lines)
    raise "duplicate section #{name}" if @sections.key?(name)

    @sections[name] = lines
  end
end

SortRubocopConfig.run("./.rubocop.yml")
```
</details>