### PR TITLE
CC-2722: spawn Puppeteer with a cleaned env

### DIFF
--- a/app/services/pdf_rendering_service.rb
+++ b/app/services/pdf_rendering_service.rb
@@ -12,6 +12,22 @@ class PdfRenderingService
   # PDF
   PDF_CONVERSION_TIMEOUT_SECONDS = 30 # seconds
 
+  # Allowlisted env for the Node/Chrome child. Do not inherit the Rails process
+  # environment: LD_PRELOAD (jemalloc) prevents Chrome from launching on Heroku,
+  # and secrets (AWS keys, DB URLs, etc.) must not be exposed to Chromium.
+  NODE_CHROME_ENV_KEYS = %w[
+    PATH
+    HOME
+    LANG
+    LD_LIBRARY_PATH
+    FONTCONFIG_PATH
+    TMPDIR
+    TMP
+    TEMP
+    SSL_CERT_FILE
+    SSL_CERT_DIR
+  ].freeze
+
   attr_reader :pdf, :html
 
   def initialize(from_html:)
@@ -80,16 +96,27 @@ class PdfRenderingService
   end
 
   def render_as_pdf(input_html_path:, output_pdf_path:, credentials:)
-    cmd = "node #{Rails.root.join('bin', 'render-pdf.js')} #{input_html_path}"\
-                                                         " #{output_pdf_path}"\
-                                                         " #{credentials[:username]}"\
-                                                         " #{credentials[:password]}"
-    Rails.logger.info(cmd)
+    cmd = [
+      'node',
+      Rails.root.join('bin', 'render-pdf.js').to_s,
+      input_html_path,
+      output_pdf_path,
+      credentials[:username].to_s,
+      credentials[:password].to_s
+    ]
+    Rails.logger.info(cmd.join(' '))
 
     error_msg = "Chrome did not complete the PDF conversion within the #{PDF_CONVERSION_TIMEOUT_SECONDS} second timeout"
 
     Timeout.timeout(PDF_CONVERSION_TIMEOUT_SECONDS, ChromeTimeoutError, error_msg) do
-      system(cmd)
+      system(node_chrome_env, *cmd, unsetenv_others: true)
+    end
+  end
+
+  def node_chrome_env
+    NODE_CHROME_ENV_KEYS.each_with_object({}) do |key, env|
+      value = ENV.fetch(key, nil)
+      env[key] = value if value.present?
     end
   end
 

--- a/spec/services/pdf_rendering_service_spec.rb
+++ b/spec/services/pdf_rendering_service_spec.rb
@@ -20,23 +20,54 @@ RSpec.describe PdfRenderingService do
 
   describe '#render' do
     let(:pdf_file_header_bytes) { '%PDF-1.4' } # PDFs begin with this sequence of bytes
+    let(:pdf_file_path) { subject.pdf.file_path }
+    let(:first_bytes_in_file) { File.read(pdf_file_path, 8) }
+
+    before { subject.render }
 
     it 'adds a base tag immediately after the <head> opening tag in the given HTML' do
-      subject.render
       expect(subject.html).to match(/<head><base href=/)
     end
 
-    context 'Saves a PDF version of the HTML file to disk' do
-      before do
-        subject.render
-        @pdf_file_path = subject.pdf.file_path
-        @first_bytes_in_file = File.read(@pdf_file_path, 8)
-      end
+    it 'saves a non-empty PDF version of the HTML file to disk' do
+      expect(File.exist?(pdf_file_path)).to eq(true)
+      expect(File.size(pdf_file_path)).to be > 0
+      expect(first_bytes_in_file).to eq(pdf_file_header_bytes)
+    end
+  end
 
-      it { expect(subject.html).to match(/<head><base href=/) }
-      it { expect(File.exist?(@pdf_file_path)).to eq(true) }
-      it { expect(File.size(@pdf_file_path)).to be > 0 }
-      it { expect(@first_bytes_in_file).to eq(pdf_file_header_bytes) }
+  describe '#node_chrome_env' do
+    around do |example|
+      ClimateControl.modify(
+        PATH: '/usr/bin',
+        HOME: '/app',
+        LANG: 'en_US.UTF-8',
+        LD_LIBRARY_PATH: '/app/.apt/usr/lib',
+        LD_PRELOAD: '/app/vendor/jemalloc/lib/libjemalloc.so',
+        DATABASE_URL: 'postgres://secret',
+        AWS_SECRET_ACCESS_KEY: 'super-secret',
+        HTTP_BASIC_AUTH_PASSWORD: 'staging-password'
+      ) { example.run }
+    end
+
+    it 'allowlists only the env Chrome/Node need' do
+      env = subject.send(:node_chrome_env)
+
+      expect(env).to eq(
+        'PATH' => '/usr/bin',
+        'HOME' => '/app',
+        'LANG' => 'en_US.UTF-8',
+        'LD_LIBRARY_PATH' => '/app/.apt/usr/lib'
+      )
+    end
+
+    it 'excludes jemalloc LD_PRELOAD and application secrets' do
+      env = subject.send(:node_chrome_env)
+
+      expect(env).not_to have_key('LD_PRELOAD')
+      expect(env).not_to have_key('DATABASE_URL')
+      expect(env).not_to have_key('AWS_SECRET_ACCESS_KEY')
+      expect(env).not_to have_key('HTTP_BASIC_AUTH_PASSWORD')
     end
   end
 end


### PR DESCRIPTION
Ticket: [CC-2722](https://ackama.atlassian.net/browse/CC-2722)

## What

Vocab sheet PDF download on staging broke after the Puppeteer v25 upgrade. Chrome never starts:

```
Error: Failed to launch the browser process:  Code: null
```

## Why

The web dyno loads jemalloc via `LD_PRELOAD` for Ruby. That value is inherited by `node bin/render-pdf.js`, then by Chrome. With jemalloc preloaded, Chrome exits immediately (null exit code, empty stderr).

We were also handing Chromium the full Rails environment (AWS keys, `DATABASE_URL`, basic-auth secrets, and so on) for no reason.

## How

`PdfRenderingService` now runs Node with `unsetenv_others: true` and an allowlist: `PATH`, `HOME`, `LANG`, `LD_LIBRARY_PATH`, plus font/tmp/SSL vars Chrome may need on Heroku. Jemalloc stays on the Ruby process; Chrome never sees it. Specs assert the allowlist and that secrets/`LD_PRELOAD` stay out.

Also switched the spawn to an argv array instead of a shell string.

## Staging proof (`heroku run` on nzsl-staging)

Same Puppeteer PDF script, two environments:

```
############################################
# A/B PROOF: Puppeteer PDF on nzsl-staging #
############################################
node=v24.19.0
chrome_cache=linux-152.0.7977.42

--- CASE 1: WITH jemalloc LD_PRELOAD ---
=== with-jemalloc ===
LD_PRELOAD=/app/vendor/jemalloc/lib/libjemalloc.so /app/vendor/jemalloc/lib/libjemalloc.so
secret_env_present=true
RESULT=FAILURE
error=Failed to launch the browser process:  Code: null

--- CASE 2: cleaned env (LD_PRELOAD cleared, secrets unset) ---
=== cleaned-env ===
LD_PRELOAD=(cleared/empty)
secret_env_present=false
RESULT=SUCCESS
pdf_path=/app/tmp/pdf_proof/cleaned-env.pdf
pdf_bytes=6883
pdf_header="%PDF-1.4"

--- SUMMARY ---
-rw------- 1 u3905 dyno 6883 Aug 25 05:38 /app/tmp/pdf_proof/cleaned-env.pdf
```

Case 1 matches production-like staging. Case 2 is what this PR does for the Node/Chrome child.