### PR TITLE
chore: update rubocop to reflect standards

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,35 @@ AllCops:
 Layout/LineLength:
   Max: 130
 
+# We think that:
+#     {
+#       foo: :bar
+#       baz: :bip
+#     }
+# Looks better than:
+#     { foo: :bar
+#       baz: :bip }
+Layout/MultilineHashBraceLayout:
+  Enabled: false
+
+# We think that:
+#    foo(
+#      bar: :baz,
+#      bip: :whizz
+#    )
+# Looks better than:
+#    foo(bar: baz,
+#        bip: :whizz)
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+# This syntax is a deliberate idiom in rspec
+# bbatsov endorses disabling it for rspec
+# https://github.com/bbatsov/rubocop/issues/4222#issuecomment-290722962
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*'
+
 Lint/Void:
   Enabled: false # see spec/controllers/vocab_sheet_controller_spec.rb
 
@@ -24,17 +53,23 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   Exclude:
-    - 'spec/**/*_spec.rb'
-    - 'config/**/*.rb'
+    - 'spec/**/*.rb'
+    - 'config/**/*'
 
 Metrics/ClassLength:
   Max: 150
+  Exclude:
+    - 'spec/**/*'
 
 Metrics/CyclomaticComplexity:
   Max: 12
 
+# We generally don't want methods longer than 20 lines, except in migrations where it's probably okay.
 Metrics/MethodLength:
   Max: 20
+  Exclude:
+    - 'db/migrate/**/*.rb'
+    - 'spec/**/*'
 
 Metrics/ModuleLength:
   Exclude:
@@ -42,6 +77,15 @@ Metrics/ModuleLength:
 
 Metrics/PerceivedComplexity:
   Max: 12
+
+# Rubocop doesn't like methods that start with `get_` or `set_`, however sometimes this is unavoidable
+# when writing pundit policies (especially where jsonapi-resources is involved).
+Naming/AccessorMethodName:
+  Exclude:
+    - 'app/policies/**/*_policy.rb'
+
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
 
 Naming/VariableNumber:
   EnforcedStyle: snake_case
@@ -127,16 +171,76 @@ Rails/WhereNot:
 Style/ArrayCoercion:
   Enabled: true
 
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+
+# We do not typically use/need class documentation
 Style/Documentation:
   Enabled: false
 
+Style/DoubleNegation:
+  Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false
+
+# Ruby supports two styles of string template formatting.
+# "annotated" - format("%<greeting>s", greeting: "Hello")
+# "template"  - format("%{greeting}", greeting: "Hello")
+#
+# While the annotated format is more descriptive, it also comes in a style that is
+# significantly harder for a developer to parse. The template style is easy to read, understand,
+# and is consistent with formatting with (for example), interpolation (#{}).
+Style/FormatStringToken:
+  EnforcedStyle: template
+
+# Ruby 2.4+ has a magic comment that makes all strings frozen and Rubocop wants to put it
+# at the top of every. single. file. We decided we didn't want that - for now.
 Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
+Style/NumericPredicate:
   Enabled: false
 
 Style/OptionalBooleanParameter:
   Enabled: false
 
 Style/PercentLiteralDelimiters:
+  Enabled: false
+
+# Disable preference for Ruby's new safe navigation operator `&.` because it
+# usually comes at the cost of expressiveness in the simple case:
+#
+#     -      coupon_usage.destroy if coupon_usage
+#     +      coupon_usage&.destroy
+#
+# And guides you towards Law of Demeter violations in the extreme case:
+#
+#     result&.data&.attributes&.payments&.first&.payment_token
+#
+# Disabling this cop doesn't stop you from using it, but be prepared to defend
+# it in code review if you do.
+Style/SafeNavigation:
+  Enabled: false
+
+# We usually don't want you to use semicolons in Ruby, except in specs where brevity is
+# often more valued than readability.
+Style/Semicolon:
+  Exclude:
+    - 'spec/**/*.rb'
+
+# Single line method definitions are totally fine, and often more readable, consider:
+#    class WidgetsPolicy
+#      def create?; false; end
+#      def index?;  true;  end
+#      def show?;   true;  end
+#      def update?; false; end
+#      def delete?; false; end
+#    end
+Style/SingleLineMethods:
   Enabled: false
 
 # Just always use double quotes and stop thinking about it.


### PR DESCRIPTION
This brings across most of our conventional configuration without adding new plugins, updating existing dependencies, or changing existing code - there's still a number of differences, but they're less now