### PR TITLE
fix: show in nav checkbox in admin

### DIFF
--- a/app/views/admin/pages/_form.html.haml
+++ b/app/views/admin/pages/_form.html.haml
@@ -22,9 +22,8 @@
         = f.text_field :label, class: "text-input"
         %small.inline-hints In the navigation -should be short.
     .small-6.column-block
-      %label
-        %input{ type: "checkbox" }
-        = f.label :show_in_nav, "Show in navigation"
+      = f.check_box :show_in_nav
+      = f.label :show_in_nav, "Show in navigation"
     .small-6.text_input
       %label.required
         = f.label :template


### PR DESCRIPTION
I discovered that ticking `show in navigation` doesn't update the `show_in_nav` field for a page. The checkbox didn't have a name matching what is in the pages controller. 

This fix adds the name to the checkbox so it submits the value properly and can update the page to show in nav. 

```
=> #<Page:0x0000000125a21b08
 id: 27,
 title: "My new page",
 slug: "my-new-page",
 label: "my new page",
 order: nil,
 template: "standard",
 show_in_nav: false,
 created_at: "2026-09-03 03:56:28.478874000 +0000",
 updated_at: "2026-09-03 03:56:28.478874000 +0000">
[3] pry(main)> page = Page.find_by(slug: 'my-new-page')
  Page Load (0.5ms)  SELECT "pages".* FROM "pages" WHERE "pages"."slug" = $1 ORDER BY "pages"."order" ASC LIMIT $2  [["slug", "my-new-page"], ["LIMIT", 1]]
=> #<Page:0x0000000100b5a648
 id: 27,
 title: "My new page",
 slug: "my-new-page",
 label: "my new page",
 order: nil,
 template: "standard",
 show_in_nav: true,
 created_at: "2026-09-03 03:56:28.478874000 +0000",
 updated_at: "2026-09-03 03:57:22.883148000 +0000">
[4] pry(main)> exit
```